### PR TITLE
3단계 - 양방향을 단방향

### DIFF
--- a/src/main/java/kitchenpos/menu/application/MenuService.java
+++ b/src/main/java/kitchenpos/menu/application/MenuService.java
@@ -5,6 +5,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.EntityNotFoundException;
 import kitchenpos.menu.domain.Menu;
+import kitchenpos.menu.domain.MenuProduct;
+import kitchenpos.menu.domain.MenuProductRepository;
 import kitchenpos.menu.domain.MenuRepository;
 import kitchenpos.menu.dto.MenuRequest;
 import kitchenpos.menu.dto.MenuResponse;
@@ -21,28 +23,36 @@ public class MenuService {
 	private final ProductService productService;
 	private final MenuGroupService menuGroupService;
 	private final MenuRepository menuRepository;
+	private final MenuProductRepository menuProductRepository;
 
 	public MenuService(
 		  final ProductService productService,
-		  MenuGroupService menuGroupService, MenuRepository menuRepository) {
+		  MenuGroupService menuGroupService, MenuRepository menuRepository,
+		  MenuProductRepository menuProductRepository) {
 		this.productService = productService;
 		this.menuGroupService = menuGroupService;
 		this.menuRepository = menuRepository;
+		this.menuProductRepository = menuProductRepository;
 	}
 
 	@Transactional
 	public MenuResponse create(final MenuRequest request) {
 		List<Product> products = productService.findAllByIds(request.getProductIds());
 		MenuGroup menuGroup = menuGroupService.findById(request.getMenuGroupId());
-		kitchenpos.menu.domain.Menu menu = request.toEntity(menuGroup, products);
-		kitchenpos.menu.domain.Menu saved = menuRepository.save(menu);
 
-		return MenuResponse.of(saved);
+		List<MenuProduct> menuProducts = request.toMenuProducts(menuGroup, products);
+		List<MenuProduct> savedMenuProducts = menuProductRepository.saveAll(menuProducts);
+
+		return MenuResponse.of(savedMenuProducts);
 	}
 
 	public List<MenuResponse> list() {
-		return menuRepository.findAll().stream()
-			  .map(MenuResponse::of)
+		List<Menu> savedMenus = menuRepository.findAll();
+		return savedMenus.stream()
+			  .map(menu -> {
+				  List<MenuProduct> menuProducts = menuProductRepository.findAllByMenu(menu);
+				  return MenuResponse.of(menuProducts);
+			  })
 			  .collect(Collectors.toList());
 	}
 

--- a/src/main/java/kitchenpos/menu/domain/Menu.java
+++ b/src/main/java/kitchenpos/menu/domain/Menu.java
@@ -1,17 +1,13 @@
 package kitchenpos.menu.domain;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import kitchenpos.menugroup.domain.MenuGroup;
 
 @Entity
@@ -26,42 +22,20 @@ public class Menu {
 	@JoinColumn(name = "menu_group_id")
 	private MenuGroup menuGroup;
 
-	@OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<MenuProduct> menuProducts = new ArrayList<>();
-
 	protected Menu() {
 	}
 
-	public Menu(String name, BigDecimal price, MenuGroup menuGroup,
-		  List<MenuProduct> menuProducts) {
-		validate(price, menuProducts);
+	public Menu(String name, BigDecimal price, MenuGroup menuGroup) {
+		validate(price);
 		this.name = name;
 		this.price = price;
 		this.menuGroup = menuGroup;
-		this.menuProducts = menuProducts;
-		setMenu();
 	}
 
-	private void setMenu() {
-		this.menuProducts.forEach(menuProduct -> menuProduct.setMenu(this));
-	}
-
-	private void validate(BigDecimal price, List<MenuProduct> menuProducts) {
+	private void validate(BigDecimal price) {
 		if (Objects.isNull(price) || price.compareTo(BigDecimal.ZERO) < 0) {
 			throw new IllegalArgumentException("메뉴의 가격은 0원 이상이어야 합니다.");
 		}
-
-		BigDecimal sumOfMenuProductPrice = sumOfMenuProductPrice(menuProducts);
-		if (price.compareTo(sumOfMenuProductPrice) != 0) {
-			throw new IllegalArgumentException("메뉴의 가격과 메뉴 항목들의 총 가격의 합이 맞지 않습니다.");
-		}
-	}
-
-	private BigDecimal sumOfMenuProductPrice(List<MenuProduct> menuProducts) {
-		return menuProducts.stream()
-			  .map(menuProduct -> menuProduct.sumOfPrice())
-			  .reduce((p1, p2) -> p1.add(p2))
-			  .orElseThrow(IllegalArgumentException::new);
 	}
 
 	public Long getId() {
@@ -78,9 +52,5 @@ public class Menu {
 
 	public MenuGroup getMenuGroup() {
 		return menuGroup;
-	}
-
-	public List<MenuProduct> getMenuProducts() {
-		return menuProducts;
 	}
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProduct.java
@@ -1,6 +1,7 @@
 package kitchenpos.menu.domain;
 
 import java.math.BigDecimal;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -15,7 +16,7 @@ public class MenuProduct {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long seq;
 
-	@ManyToOne
+	@ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
 	@JoinColumn(name = "menu_id")
 	private Menu menu;
 
@@ -28,20 +29,8 @@ public class MenuProduct {
 	protected MenuProduct() {
 	}
 
-	public MenuProduct(Long seq, Menu menu, Product product, long quantity) {
-		this.seq = seq;
-		this.menu = menu;
-		this.product = product;
-		this.quantity = quantity;
-	}
-
 	public MenuProduct(Menu menu, Product product, long quantity) {
 		this.menu = menu;
-		this.product = product;
-		this.quantity = quantity;
-	}
-
-	public MenuProduct(Product product, long quantity) {
 		this.product = product;
 		this.quantity = quantity;
 	}

--- a/src/main/java/kitchenpos/menu/domain/MenuProductRepository.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProductRepository.java
@@ -1,0 +1,9 @@
+package kitchenpos.menu.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuProductRepository extends JpaRepository<MenuProduct, Long> {
+
+	List<MenuProduct> findAllByMenu(Menu menu);
+}

--- a/src/main/java/kitchenpos/menu/dto/MenuResponse.java
+++ b/src/main/java/kitchenpos/menu/dto/MenuResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import kitchenpos.menu.domain.Menu;
+import kitchenpos.menu.domain.MenuProduct;
 
 public class MenuResponse {
 
@@ -26,13 +27,15 @@ public class MenuResponse {
 		this.menuProducts = menuProducts;
 	}
 
-	public static MenuResponse of(Menu menu) {
-		List<MenuProductResponse> menuProductResponse = menu.getMenuProducts().stream()
+	public static MenuResponse of(List<MenuProduct> savedMenuProducts) {
+		List<MenuProductResponse> menuProductResponse = savedMenuProducts.stream()
 			  .map(MenuProductResponse::of)
 			  .collect(Collectors.toList());
 
-		return new MenuResponse(menu.getId(), menu.getName(), menu.getPrice(),
-			  menu.getMenuGroup().getId(), menuProductResponse);
+		Menu savedMenu = savedMenuProducts.get(0).getMenu();
+
+		return new MenuResponse(savedMenu.getId(), savedMenu.getName(), savedMenu.getPrice(),
+			  savedMenu.getMenuGroup().getId(), menuProductResponse);
 	}
 
 	public Long getId() {

--- a/src/main/java/kitchenpos/order/application/OrderQueryService.java
+++ b/src/main/java/kitchenpos/order/application/OrderQueryService.java
@@ -2,6 +2,8 @@ package kitchenpos.order.application;
 
 import java.util.List;
 import javax.persistence.EntityNotFoundException;
+import kitchenpos.order.domain.OrderLineItem;
+import kitchenpos.order.domain.OrderLineItemRepository;
 import kitchenpos.order.domain.OrderRepository;
 import kitchenpos.order.domain.Orders;
 import kitchenpos.ordertable.domain.OrderTable;
@@ -11,9 +13,12 @@ import org.springframework.stereotype.Service;
 public class OrderQueryService {
 
 	private final OrderRepository orderRepository;
+	private final OrderLineItemRepository orderLineItemRepository;
 
-	public OrderQueryService(OrderRepository orderRepository) {
+	public OrderQueryService(OrderRepository orderRepository,
+		  OrderLineItemRepository orderLineItemRepository) {
 		this.orderRepository = orderRepository;
+		this.orderLineItemRepository = orderLineItemRepository;
 	}
 
 	public List<Orders> findAllByOrderTable(OrderTable orderTable) {
@@ -27,5 +32,17 @@ public class OrderQueryService {
 	public Orders findById(Long orderId) {
 		return orderRepository.findById(orderId)
 			  .orElseThrow(EntityNotFoundException::new);
+	}
+
+	public List<OrderLineItem> findAllOrderLineItems(Orders order) {
+		return orderLineItemRepository.findAllByOrders(order);
+	}
+
+	public Orders save(Orders entity) {
+		return orderRepository.save(entity);
+	}
+
+	public List<OrderLineItem> saveOrderLineItems(List<OrderLineItem> orderLineItems) {
+		return orderLineItemRepository.saveAll(orderLineItems);
 	}
 }

--- a/src/main/java/kitchenpos/order/application/OrderQueryService.java
+++ b/src/main/java/kitchenpos/order/application/OrderQueryService.java
@@ -1,0 +1,31 @@
+package kitchenpos.order.application;
+
+import java.util.List;
+import javax.persistence.EntityNotFoundException;
+import kitchenpos.order.domain.OrderRepository;
+import kitchenpos.order.domain.Orders;
+import kitchenpos.ordertable.domain.OrderTable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderQueryService {
+
+	private final OrderRepository orderRepository;
+
+	public OrderQueryService(OrderRepository orderRepository) {
+		this.orderRepository = orderRepository;
+	}
+
+	public List<Orders> findAllByOrderTable(OrderTable orderTable) {
+		return orderRepository.findAllByOrderTable(orderTable);
+	}
+
+	public List<Orders> findAll() {
+		return orderRepository.findAll();
+	}
+
+	public Orders findById(Long orderId) {
+		return orderRepository.findById(orderId)
+			  .orElseThrow(EntityNotFoundException::new);
+	}
+}

--- a/src/main/java/kitchenpos/order/application/OrderService.java
+++ b/src/main/java/kitchenpos/order/application/OrderService.java
@@ -3,14 +3,13 @@ package kitchenpos.order.application;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.persistence.EntityNotFoundException;
 import kitchenpos.menu.application.MenuService;
 import kitchenpos.menu.domain.Menu;
 import kitchenpos.order.domain.OrderRepository;
 import kitchenpos.order.domain.Orders;
 import kitchenpos.order.dto.OrderRequest;
 import kitchenpos.order.dto.OrderResponse;
-import kitchenpos.ordertable.application.OrderTableService;
+import kitchenpos.ordertable.application.OrderTableQueryService;
 import kitchenpos.ordertable.domain.OrderTable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,14 +17,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class OrderService {
 
-	private final OrderTableService orderTableService;
+	private final OrderQueryService orderQueryService;
+	private final OrderTableQueryService orderTableQueryService;
 	private final MenuService menuService;
 	private final OrderRepository orderRepository;
 
 	public OrderService(
-		  OrderTableService orderTableService, MenuService menuService,
+		  OrderQueryService orderQueryService,
+		  OrderTableQueryService orderTableQueryService,
+		  MenuService menuService,
 		  OrderRepository orderRepository) {
-		this.orderTableService = orderTableService;
+		this.orderQueryService = orderQueryService;
+		this.orderTableQueryService = orderTableQueryService;
 		this.menuService = menuService;
 		this.orderRepository = orderRepository;
 	}
@@ -34,14 +37,14 @@ public class OrderService {
 	public OrderResponse create(final OrderRequest request) {
 		Set<Long> menuIds = request.menuIds();
 		List<Menu> menus = menuService.findAllByIds(menuIds);
-		OrderTable orderTable = orderTableService.findById(request.getOrderTableId());
+		OrderTable orderTable = orderTableQueryService.findById(request.getOrderTableId());
 
 		Orders savedOrder = orderRepository.save(request.toEntity(orderTable, menus));
 		return OrderResponse.of(savedOrder);
 	}
 
 	public List<OrderResponse> list() {
-		List<Orders> orders = orderRepository.findAll();
+		List<Orders> orders = orderQueryService.findAll();
 		return orders.stream()
 			  .map(OrderResponse::of)
 			  .collect(Collectors.toList());
@@ -49,13 +52,8 @@ public class OrderService {
 
 	@Transactional
 	public OrderResponse changeOrderStatus(final Long orderId, final OrderRequest request) {
-		Orders order = findById(orderId);
+		Orders order = orderQueryService.findById(orderId);
 		order.changeStatus(request.getOrderStatus());
 		return OrderResponse.of(order);
-	}
-
-	private Orders findById(Long orderId) {
-		return orderRepository.findById(orderId)
-			  .orElseThrow(EntityNotFoundException::new);
 	}
 }

--- a/src/main/java/kitchenpos/order/domain/OrderLineItem.java
+++ b/src/main/java/kitchenpos/order/domain/OrderLineItem.java
@@ -27,7 +27,8 @@ public class OrderLineItem {
     protected OrderLineItem() {
     }
 
-    public OrderLineItem(Menu menu, long quantity) {
+    public OrderLineItem(Orders order, Menu menu, long quantity) {
+        this.orders = order;
         this.menu = menu;
         this.quantity = quantity;
     }

--- a/src/main/java/kitchenpos/order/domain/OrderLineItemRepository.java
+++ b/src/main/java/kitchenpos/order/domain/OrderLineItemRepository.java
@@ -1,0 +1,9 @@
+package kitchenpos.order.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderLineItemRepository extends JpaRepository<OrderLineItem, Long> {
+
+	List<OrderLineItem> findAllByOrders(Orders order);
+}

--- a/src/main/java/kitchenpos/order/domain/OrderList.java
+++ b/src/main/java/kitchenpos/order/domain/OrderList.java
@@ -1,0 +1,20 @@
+package kitchenpos.order.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public class OrderList {
+	private List<Orders> orderList;
+
+	public OrderList(List<Orders> orderList) {
+		this.orderList = orderList;
+	}
+
+	public boolean isCompleteAllOrders() {
+		Optional<Orders> notCompleteOrder = this.orderList.stream()
+			  .filter(order -> !OrderStatus.COMPLETION.name().equals(order.getOrderStatus()))
+			  .findFirst();
+
+		return !notCompleteOrder.isPresent();
+	}
+}

--- a/src/main/java/kitchenpos/order/domain/OrderRepository.java
+++ b/src/main/java/kitchenpos/order/domain/OrderRepository.java
@@ -1,7 +1,10 @@
 package kitchenpos.order.domain;
 
+import java.util.List;
+import kitchenpos.ordertable.domain.OrderTable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Orders, Long> {
 
+	List<Orders> findAllByOrderTable(OrderTable orderTable);
 }

--- a/src/main/java/kitchenpos/order/domain/Orders.java
+++ b/src/main/java/kitchenpos/order/domain/Orders.java
@@ -1,101 +1,75 @@
 package kitchenpos.order.domain;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.PrePersist;
 import kitchenpos.ordertable.domain.OrderTable;
-import org.springframework.util.CollectionUtils;
 
 @Entity
 public class Orders {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "order_table_id")
-    private OrderTable orderTable;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    private String orderStatus;
+	@ManyToOne
+	@JoinColumn(name = "order_table_id")
+	private OrderTable orderTable;
 
-    private LocalDateTime orderedTime;
+	private String orderStatus;
 
-    @OneToMany(mappedBy = "orders", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<OrderLineItem> orderLineItems = new ArrayList<>();
+	private LocalDateTime orderedTime;
 
+	protected Orders() {
+	}
 
-    protected Orders() {
-    }
+	public Orders(OrderTable orderTable, String orderStatus) {
+		validate(orderTable);
+		this.orderTable = orderTable;
+		this.orderStatus = orderStatus;
+	}
 
-    public Orders(OrderTable orderTable, String orderStatus,
-          List<OrderLineItem> orderLineItems) {
-        validate(orderTable, orderLineItems);
+	public Orders(String orderStatus) {
+		this.orderStatus = orderStatus;
+	}
 
-        this.orderTable = orderTable;
-        this.orderStatus = orderStatus;
-        this.orderLineItems = orderLineItems;
-        setOrder();
-    }
+	public void changeStatus(String orderStatus) {
+		if (OrderStatus.COMPLETION.name().equals(this.orderStatus)) {
+			throw new IllegalArgumentException("결제 완료된 주문은 상태를 변경할 수 없습니다.");
+		}
 
-    public Orders(String orderStatus) {
-        this.orderStatus = orderStatus;
-    }
+		this.orderStatus = orderStatus;
+	}
 
-    public void changeStatus(String orderStatus) {
-        if (OrderStatus.COMPLETION.name().equals(this.orderStatus)) {
-            throw new IllegalArgumentException("결제 완료된 주문은 상태를 변경할 수 없습니다.");
-        }
+	private void validate(OrderTable orderTable) {
+		if (orderTable.isEmpty()) {
+			throw new IllegalArgumentException("테이블이 비어있습니다.");
+		}
+	}
 
-        this.orderStatus = orderStatus;
-    }
+	public Long getId() {
+		return id;
+	}
 
-    private void setOrder() {
-        this.orderLineItems.forEach(orderLineItem ->
-            orderLineItem.setOrder(this)
-        );
-    }
+	public OrderTable getOrderTable() {
+		return orderTable;
+	}
 
-    private void validate(OrderTable orderTable, List<OrderLineItem> orderLineItems) {
-        if (orderTable.isEmpty()) {
-            throw new IllegalArgumentException("테이블이 비어있습니다.");
-        }
+	public String getOrderStatus() {
+		return orderStatus;
+	}
 
-        if (CollectionUtils.isEmpty(orderLineItems)) {
-            throw new IllegalArgumentException("주문 항목이 비어있습니다.");
-        }
-    }
+	public LocalDateTime getOrderedTime() {
+		return orderedTime;
+	}
 
-    public Long getId() {
-        return id;
-    }
-
-    public OrderTable getOrderTable() {
-        return orderTable;
-    }
-
-    public String getOrderStatus() {
-        return orderStatus;
-    }
-
-    public LocalDateTime getOrderedTime() {
-        return orderedTime;
-    }
-
-    public List<OrderLineItem> getOrderLineItems() {
-        return orderLineItems;
-    }
-
-    @PrePersist
-    public void prePersist() {
-        this.orderedTime = LocalDateTime.now();
-    }
+	@PrePersist
+	public void prePersist() {
+		this.orderedTime = LocalDateTime.now();
+	}
 }

--- a/src/main/java/kitchenpos/order/domain/Orders.java
+++ b/src/main/java/kitchenpos/order/domain/Orders.java
@@ -59,10 +59,9 @@ public class Orders {
     }
 
     private void setOrder() {
-        this.orderTable.setOrder(this);
-        this.orderLineItems.forEach(orderLineItem -> {
-            orderLineItem.setOrder(this);
-        });
+        this.orderLineItems.forEach(orderLineItem ->
+            orderLineItem.setOrder(this)
+        );
     }
 
     private void validate(OrderTable orderTable, List<OrderLineItem> orderLineItems) {

--- a/src/main/java/kitchenpos/order/dto/OrderRequest.java
+++ b/src/main/java/kitchenpos/order/dto/OrderRequest.java
@@ -38,14 +38,14 @@ public class OrderRequest {
 			  .collect(Collectors.toSet());
 	}
 
-	public Orders toEntity(OrderTable orderTable, List<Menu> menus) {
+	public Orders toOrderEntity(OrderTable orderTable) {
 		OrderStatus orderStatus = StringUtils.isBlank(this.orderStatus) ? OrderStatus.COOKING
 			  : OrderStatus.valueOf(this.orderStatus);
 
-		return new Orders(orderTable, orderStatus.name(), toOrderLineItems(menus));
+		return new Orders(orderTable, orderStatus.name());
 	}
 
-	private List<OrderLineItem> toOrderLineItems(List<Menu> menus) {
+	public List<OrderLineItem> toOrderLineItems(Orders order, List<Menu> menus) {
 		Map<Long, Menu> menuInfo = menus.stream()
 			  .collect(Collectors.toMap(Menu::getId, Function.identity()));
 
@@ -53,7 +53,7 @@ public class OrderRequest {
 			  .filter(orderLineItem -> menuInfo.containsKey(orderLineItem.getMenuId()))
 			  .map(orderLineItem -> {
 				  Menu menu = menuInfo.get(orderLineItem.getMenuId());
-				  return new OrderLineItem(menu, orderLineItem.getQuantity());
+				  return new OrderLineItem(order, menu, orderLineItem.getQuantity());
 			  })
 			  .collect(Collectors.toList());
 	}

--- a/src/main/java/kitchenpos/order/dto/OrderResponse.java
+++ b/src/main/java/kitchenpos/order/dto/OrderResponse.java
@@ -3,6 +3,7 @@ package kitchenpos.order.dto;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import kitchenpos.order.domain.OrderLineItem;
 import kitchenpos.order.domain.Orders;
 
 public class OrderResponse {
@@ -24,10 +25,16 @@ public class OrderResponse {
 	}
 
 	public static OrderResponse of(Orders savedOrders) {
-		List<OrderLineItemResponse> orderLineItemResponses = savedOrders.getOrderLineItems().stream()
+		return new OrderResponse(savedOrders.getId(), savedOrders.getOrderTable().getId(),
+			  savedOrders.getOrderStatus(), null);
+	}
+
+	public static OrderResponse of(List<OrderLineItem> orderLineItems) {
+		List<OrderLineItemResponse> orderLineItemResponses = orderLineItems.stream()
 			  .map(OrderLineItemResponse::of)
 			  .collect(Collectors.toList());
 
+		Orders savedOrders = orderLineItems.get(0).getOrder();
 		return new OrderResponse(savedOrders.getId(), savedOrders.getOrderTable().getId(),
 			  savedOrders.getOrderStatus(), orderLineItemResponses);
 	}

--- a/src/main/java/kitchenpos/ordertable/application/OrderTableQueryService.java
+++ b/src/main/java/kitchenpos/ordertable/application/OrderTableQueryService.java
@@ -1,0 +1,32 @@
+package kitchenpos.ordertable.application;
+
+import java.util.List;
+import java.util.Set;
+import javax.persistence.EntityNotFoundException;
+import kitchenpos.ordertable.domain.OrderTable;
+import kitchenpos.ordertable.domain.OrderTableRepository;
+import kitchenpos.tablegroup.domain.TableGroup;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderTableQueryService {
+	private final OrderTableRepository orderTableRepository;
+
+	public OrderTableQueryService(
+		  OrderTableRepository orderTableRepository) {
+		this.orderTableRepository = orderTableRepository;
+	}
+
+	public OrderTable findById(Long orderTableId) {
+		return orderTableRepository.findById(orderTableId)
+			  .orElseThrow(EntityNotFoundException::new);
+	}
+
+	public List<OrderTable> findAllByOrderTableIds(Set<Long> orderTableIds) {
+		return orderTableRepository.findAllById(orderTableIds);
+	}
+
+	public List<OrderTable> findAllByTableGroup(TableGroup tableGroup) {
+		return orderTableRepository.findAllByTableGroup(tableGroup);
+	}
+}

--- a/src/main/java/kitchenpos/ordertable/application/OrderTableQueryService.java
+++ b/src/main/java/kitchenpos/ordertable/application/OrderTableQueryService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class OrderTableQueryService {
+
 	private final OrderTableRepository orderTableRepository;
 
 	public OrderTableQueryService(
@@ -28,5 +29,13 @@ public class OrderTableQueryService {
 
 	public List<OrderTable> findAllByTableGroup(TableGroup tableGroup) {
 		return orderTableRepository.findAllByTableGroup(tableGroup);
+	}
+
+	public OrderTable save(OrderTable entity) {
+		return orderTableRepository.save(entity);
+	}
+
+	public List<OrderTable> findAll() {
+		return orderTableRepository.findAll();
 	}
 }

--- a/src/main/java/kitchenpos/ordertable/application/OrderTableService.java
+++ b/src/main/java/kitchenpos/ordertable/application/OrderTableService.java
@@ -6,7 +6,6 @@ import kitchenpos.order.application.OrderQueryService;
 import kitchenpos.order.domain.OrderList;
 import kitchenpos.order.domain.Orders;
 import kitchenpos.ordertable.domain.OrderTable;
-import kitchenpos.ordertable.domain.OrderTableRepository;
 import kitchenpos.ordertable.dto.OrderTableRequest;
 import kitchenpos.ordertable.dto.OrderTableResponse;
 import kitchenpos.tablegroup.domain.TableGroup;
@@ -19,24 +18,21 @@ public class OrderTableService {
 
 	private final OrderQueryService orderQueryService;
 	private final OrderTableQueryService orderTableQueryService;
-	private final OrderTableRepository orderTableRepository;
 
 	public OrderTableService(
 		  OrderQueryService orderQueryService,
-		  OrderTableQueryService orderTableQueryService,
-		  OrderTableRepository orderTableRepository) {
+		  OrderTableQueryService orderTableQueryService) {
 		this.orderQueryService = orderQueryService;
 		this.orderTableQueryService = orderTableQueryService;
-		this.orderTableRepository = orderTableRepository;
 	}
 
 	public OrderTableResponse create(final OrderTableRequest request) {
-		OrderTable savedOrderTable = orderTableRepository.save(request.newEntity());
+		OrderTable savedOrderTable = orderTableQueryService.save(request.newEntity());
 		return OrderTableResponse.of(savedOrderTable);
 	}
 
 	public List<OrderTableResponse> list() {
-		return orderTableRepository.findAll().stream()
+		return orderTableQueryService.findAll().stream()
 			  .map(OrderTableResponse::of)
 			  .collect(Collectors.toList());
 	}

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
@@ -11,6 +11,7 @@ import kitchenpos.tablegroup.domain.TableGroup;
 
 @Entity(name = "order_table")
 public class OrderTable {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -59,30 +60,6 @@ public class OrderTable {
 		this.tableGroup = null;
 	}
 
-//	@Deprecated
-//	public void changeEmpty(boolean empty) {
-//		validateCompleteAllOrders();
-//		validateNumberOfGuest();
-//		this.empty = empty;
-//	}
-
-//	@Deprecated
-//	public void unTableGroup() {
-//		validateCompleteAllOrders();
-//		this.tableGroup = null;
-//	}
-
-//	@Deprecated
-//	private void validateCompleteAllOrders() {
-//		Optional<Orders> notCompleteOrder = this.orders.stream()
-//			  .filter(order -> !OrderStatus.COMPLETION.name().equals(order.getOrderStatus()))
-//			  .findFirst();
-//
-//		if (notCompleteOrder.isPresent()) {
-//			throw new IllegalArgumentException("조리, 식사 상태의 테이블은 상태를 변경할 수 없습니다.");
-//		}
-//	}
-
 	private void validateCompleteAllOrders(boolean allOrderCompleted) {
 		if (!allOrderCompleted) {
 			throw new IllegalArgumentException("조리, 식사 상태의 테이블은 상태를 변경할 수 없습니다.");
@@ -108,10 +85,6 @@ public class OrderTable {
 	public boolean isJoinedTableGroup() {
 		return this.tableGroup != null;
 	}
-
-//	public void setOrders(Orders order) {
-//		this.orders.add(order);
-//	}
 
 	public void setTableGroup(TableGroup tableGroup) {
 		this.tableGroup = tableGroup;

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
@@ -1,17 +1,12 @@
 package kitchenpos.ordertable.domain;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import kitchenpos.order.domain.OrderStatus;
-import kitchenpos.order.domain.Orders;
 import kitchenpos.tablegroup.domain.TableGroup;
 
 @Entity(name = "order_table")
@@ -22,12 +17,9 @@ public class OrderTable {
 	private int numberOfGuests;
 	private boolean empty;
 
-	@ManyToOne
+	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "table_group_id")
 	private TableGroup tableGroup;
-
-	@OneToMany(mappedBy = "orderTable")
-	private List<Orders> orders = new ArrayList<>();
 
 	protected OrderTable() {
 	}
@@ -52,23 +44,47 @@ public class OrderTable {
 		this.numberOfGuests = numberOfGuests;
 	}
 
-	public void changeEmpty(boolean empty) {
-		validateCompleteAllOrders();
+	public void changeEmpty(boolean empty, boolean allOrderCompleted) {
+		validateCompleteAllOrders(allOrderCompleted);
 		validateNumberOfGuest();
 		this.empty = empty;
 	}
 
-	public void unTableGroup() {
-		validateCompleteAllOrders();
+	public void group(TableGroup tableGroup) {
+		this.tableGroup = tableGroup;
+	}
+
+	public void unGroup(boolean allOrderCompleted) {
+		validateCompleteAllOrders(allOrderCompleted);
 		this.tableGroup = null;
 	}
 
-	private void validateCompleteAllOrders() {
-		Optional<Orders> notCompleteOrder = this.orders.stream()
-			  .filter(order -> !OrderStatus.COMPLETION.name().equals(order.getOrderStatus()))
-			  .findFirst();
+//	@Deprecated
+//	public void changeEmpty(boolean empty) {
+//		validateCompleteAllOrders();
+//		validateNumberOfGuest();
+//		this.empty = empty;
+//	}
 
-		if (notCompleteOrder.isPresent()) {
+//	@Deprecated
+//	public void unTableGroup() {
+//		validateCompleteAllOrders();
+//		this.tableGroup = null;
+//	}
+
+//	@Deprecated
+//	private void validateCompleteAllOrders() {
+//		Optional<Orders> notCompleteOrder = this.orders.stream()
+//			  .filter(order -> !OrderStatus.COMPLETION.name().equals(order.getOrderStatus()))
+//			  .findFirst();
+//
+//		if (notCompleteOrder.isPresent()) {
+//			throw new IllegalArgumentException("조리, 식사 상태의 테이블은 상태를 변경할 수 없습니다.");
+//		}
+//	}
+
+	private void validateCompleteAllOrders(boolean allOrderCompleted) {
+		if (!allOrderCompleted) {
 			throw new IllegalArgumentException("조리, 식사 상태의 테이블은 상태를 변경할 수 없습니다.");
 		}
 	}
@@ -93,9 +109,9 @@ public class OrderTable {
 		return this.tableGroup != null;
 	}
 
-	public void setOrder(Orders orders) {
-		this.orders.add(orders);
-	}
+//	public void setOrders(Orders order) {
+//		this.orders.add(order);
+//	}
 
 	public void setTableGroup(TableGroup tableGroup) {
 		this.tableGroup = tableGroup;

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTableRepository.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTableRepository.java
@@ -1,7 +1,10 @@
 package kitchenpos.ordertable.domain;
 
+import java.util.List;
+import kitchenpos.tablegroup.domain.TableGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderTableRepository extends JpaRepository<OrderTable, Long> {
 
+	List<OrderTable> findAllByTableGroup(TableGroup tableGroupId);
 }

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTables.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTables.java
@@ -14,19 +14,11 @@ public class OrderTables {
 		this.orderTables = savedOrderTables;
 	}
 
-	public OrderTables(List<OrderTable> savedOrderTables) {
-		this.orderTables = savedOrderTables;
-	}
-
 	public void group(TableGroup tableGroup) {
 		this.orderTables.forEach(
 			  orderTable -> orderTable.group(tableGroup)
 		);
 	}
-
-//	public void unTableGroup() {
-//		this.orderTables.forEach(OrderTable::unTableGroup);
-//	}
 
 	private void validate(List<OrderTable> savedOrderTables, int requestSize) {
 		if (CollectionUtils.isEmpty(savedOrderTables) || savedOrderTables.size() < 2) {

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTables.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTables.java
@@ -1,31 +1,32 @@
 package kitchenpos.ordertable.domain;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.persistence.CascadeType;
-import javax.persistence.Embeddable;
-import javax.persistence.OneToMany;
 import kitchenpos.tablegroup.domain.TableGroup;
 import org.springframework.util.CollectionUtils;
 
-@Embeddable
 public class OrderTables {
 
-	@OneToMany(mappedBy = "tableGroup", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-	private List<OrderTable> orderTables = new ArrayList<>();
-
-	public OrderTables() {
-	}
+	private List<OrderTable> orderTables;
 
 	public OrderTables(List<OrderTable> savedOrderTables, int size) {
 		validate(savedOrderTables, size);
 		this.orderTables = savedOrderTables;
 	}
 
-	public void unTableGroup() {
-		this.orderTables.forEach(OrderTable::unTableGroup);
+	public OrderTables(List<OrderTable> savedOrderTables) {
+		this.orderTables = savedOrderTables;
 	}
+
+	public void group(TableGroup tableGroup) {
+		this.orderTables.forEach(
+			  orderTable -> orderTable.group(tableGroup)
+		);
+	}
+
+//	public void unTableGroup() {
+//		this.orderTables.forEach(OrderTable::unTableGroup);
+//	}
 
 	private void validate(List<OrderTable> savedOrderTables, int requestSize) {
 		if (CollectionUtils.isEmpty(savedOrderTables) || savedOrderTables.size() < 2) {
@@ -51,5 +52,9 @@ public class OrderTables {
 
 	public void setTableGroup(TableGroup tableGroup) {
 		this.orderTables.forEach(orderTable -> orderTable.setTableGroup(tableGroup));
+	}
+
+	public TableGroup getRespTableGroup() {
+		return this.orderTables.get(0).getTableGroup();
 	}
 }

--- a/src/main/java/kitchenpos/tablegroup/application/TableGroupService.java
+++ b/src/main/java/kitchenpos/tablegroup/application/TableGroupService.java
@@ -2,6 +2,7 @@ package kitchenpos.tablegroup.application;
 
 import java.util.List;
 import javax.persistence.EntityNotFoundException;
+import kitchenpos.ordertable.application.OrderTableQueryService;
 import kitchenpos.ordertable.application.OrderTableService;
 import kitchenpos.ordertable.domain.OrderTable;
 import kitchenpos.ordertable.domain.OrderTables;
@@ -15,30 +16,35 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TableGroupService {
 
+	private final OrderTableQueryService orderTableQueryService;
 	private final OrderTableService orderTableService;
 	private final TableGroupRepository tableGroupRepository;
 
-	public TableGroupService(OrderTableService orderTableService,
+	public TableGroupService(
+		  OrderTableQueryService orderTableQueryService,
+		  OrderTableService orderTableService,
 		  TableGroupRepository tableGroupRepository) {
+		this.orderTableQueryService = orderTableQueryService;
 		this.orderTableService = orderTableService;
 		this.tableGroupRepository = tableGroupRepository;
 	}
 
 	@Transactional
 	public TableGroupResponse create(final TableGroupRequest request) {
-		List<OrderTable> savedOrderTables = orderTableService
+		List<OrderTable> savedOrderTables = orderTableQueryService
 			  .findAllByOrderTableIds(request.getOrderTableIds());
 
 		OrderTables orderTables = new OrderTables(savedOrderTables, request.getRequestSize());
+		TableGroup savedTableGroup = tableGroupRepository.save(TableGroup.newInstance());
+		orderTables.group(savedTableGroup);
 
-		TableGroup savedTableGroup = tableGroupRepository.save(request.toEntity(orderTables));
-		return TableGroupResponse.of(savedTableGroup);
+		return TableGroupResponse.of(orderTables);
 	}
 
 	@Transactional
 	public void ungroup(final Long tableGroupId) {
 		TableGroup tableGroup = findById(tableGroupId);
-		tableGroup.unTableGroup();
+		orderTableService.unGroup(tableGroup);
 		tableGroupRepository.deleteById(tableGroup.getId());
 	}
 

--- a/src/main/java/kitchenpos/tablegroup/domain/TableGroup.java
+++ b/src/main/java/kitchenpos/tablegroup/domain/TableGroup.java
@@ -1,13 +1,11 @@
 package kitchenpos.tablegroup.domain;
 
 import java.time.LocalDateTime;
-import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PrePersist;
-import kitchenpos.ordertable.domain.OrderTables;
 
 @Entity(name = "table_group")
 public class TableGroup {
@@ -17,19 +15,11 @@ public class TableGroup {
 	private Long id;
 	private LocalDateTime createdDate;
 
-	@Embedded
-	private OrderTables orderTables = new OrderTables();
-
 	protected TableGroup() {
 	}
 
-	public TableGroup(OrderTables orderTables) {
-		this.orderTables = orderTables;
-		this.orderTables.setTableGroup(this);
-	}
-
-	public void unTableGroup() {
-		this.orderTables.unTableGroup();
+	public static TableGroup newInstance() {
+		return new TableGroup();
 	}
 
 	@PrePersist
@@ -43,9 +33,5 @@ public class TableGroup {
 
 	public LocalDateTime getCreatedDate() {
 		return createdDate;
-	}
-
-	public OrderTables getOrderTables() {
-		return orderTables;
 	}
 }

--- a/src/main/java/kitchenpos/tablegroup/dto/TableGroupRequest.java
+++ b/src/main/java/kitchenpos/tablegroup/dto/TableGroupRequest.java
@@ -1,8 +1,6 @@
 package kitchenpos.tablegroup.dto;
 
 import java.util.Set;
-import kitchenpos.ordertable.domain.OrderTables;
-import kitchenpos.tablegroup.domain.TableGroup;
 
 public class TableGroupRequest {
 
@@ -14,10 +12,6 @@ public class TableGroupRequest {
 
 	public TableGroupRequest(Set<Long> orderTableIds) {
 		this.orderTableIds = orderTableIds;
-	}
-
-	public TableGroup toEntity(OrderTables orderTables) {
-		return new TableGroup(orderTables);
 	}
 
 	public Long getId() {

--- a/src/main/java/kitchenpos/tablegroup/dto/TableGroupResponse.java
+++ b/src/main/java/kitchenpos/tablegroup/dto/TableGroupResponse.java
@@ -3,6 +3,7 @@ package kitchenpos.tablegroup.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import kitchenpos.ordertable.domain.OrderTables;
 import kitchenpos.ordertable.dto.OrderTableResponse;
 import kitchenpos.tablegroup.domain.TableGroup;
 
@@ -19,9 +20,11 @@ public class TableGroupResponse {
 		this.orderTables = orderTables;
 	}
 
-	public static TableGroupResponse of(TableGroup tableGroup) {
+	public static TableGroupResponse of(OrderTables updatedOrderTables) {
+		TableGroup tableGroup = updatedOrderTables.getRespTableGroup();
+
 		return new TableGroupResponse(tableGroup.getId(), tableGroup.getCreatedDate(),
-			  tableGroup.getOrderTables().getOrderTables().stream()
+			  updatedOrderTables.getOrderTables().stream()
 					.map(OrderTableResponse::of)
 					.collect(Collectors.toList())
 		);

--- a/src/test/java/kitchenpos/menu/domain/MenuTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuTest.java
@@ -3,11 +3,8 @@ package kitchenpos.menu.domain;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
-import kitchenpos.product.domain.Product;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 class MenuTest {
 
@@ -16,25 +13,8 @@ class MenuTest {
 	void createWithUnderZeroPrice() {
 		assertThatIllegalArgumentException()
 			  .isThrownBy(() ->
-					new Menu("신메뉴", new BigDecimal(-1), null,
-						  Arrays.asList(new MenuProduct()))
+					new Menu("신메뉴", new BigDecimal(-1), null)
 			  )
 			  .withMessage("메뉴의 가격은 0원 이상이어야 합니다.");
-	}
-
-	@DisplayName("메뉴의 가격과 메뉴 상품들의 총 가격이 맞지 않는 경우 메뉴를 등록할 수 없음")
-	@Test
-	void createWithUnMatchPrice() {
-		Product product = new Product("상품", new BigDecimal(1));
-		MenuProduct menuProduct = new MenuProduct();
-		ReflectionTestUtils.setField(menuProduct, "product", product);
-		ReflectionTestUtils.setField(menuProduct, "quantity", 1L);
-
-		assertThatIllegalArgumentException()
-			  .isThrownBy(() ->
-					new Menu("신메뉴", new BigDecimal(0), null,
-						  Arrays.asList(menuProduct))
-			  )
-			  .withMessage("메뉴의 가격과 메뉴 항목들의 총 가격의 합이 맞지 않습니다.");
 	}
 }

--- a/src/test/java/kitchenpos/menu/dto/MenuRequestTest.java
+++ b/src/test/java/kitchenpos/menu/dto/MenuRequestTest.java
@@ -1,0 +1,23 @@
+package kitchenpos.menu.dto;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MenuRequestTest {
+
+	@DisplayName("메뉴의 가격과 메뉴 상품들의 총 가격이 맞지 않는 경우 메뉴를 등록할 수 없음")
+	@Test
+	void createWithUnMatchPrice() {
+		MenuRequest menuRequest = new MenuRequest("신메뉴", new BigDecimal(100), null, null);
+		assertThatIllegalArgumentException()
+			  .isThrownBy(() ->
+					ReflectionTestUtils
+						  .invokeMethod(menuRequest, "validatePrice", new BigDecimal(99))
+			  )
+			  .withMessage("메뉴의 가격과 메뉴 항목들의 총 가격의 합이 맞지 않습니다.");
+	}
+}

--- a/src/test/java/kitchenpos/order/domain/OrderTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderTest.java
@@ -9,17 +9,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-class OrdersTest {
+class OrderTest {
 
 	@DisplayName("결제완료된 주문은 상태를 변경할 수 없음")
 	@Test
 	void changeOrderStatus() {
-		Orders orders = new Orders();
-		ReflectionTestUtils.setField(orders, "orderStatus", OrderStatus.COMPLETION.name());
+		Orders order = new Orders();
+		ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.COMPLETION.name());
 
 		//when, then
 		assertThatIllegalArgumentException()
-			  .isThrownBy(() -> orders.changeStatus(OrderStatus.MEAL.name()))
+			  .isThrownBy(() -> order.changeStatus(OrderStatus.MEAL.name()))
 			  .withMessage("결제 완료된 주문은 상태를 변경할 수 없습니다.")
 		;
 	}

--- a/src/test/java/kitchenpos/order/domain/OrdersTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrdersTest.java
@@ -2,14 +2,12 @@ package kitchenpos.order.domain;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import kitchenpos.ordertable.domain.OrderTable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-class OrderTest {
+class OrdersTest {
 
 	@DisplayName("결제완료된 주문은 상태를 변경할 수 없음")
 	@Test
@@ -20,8 +18,7 @@ class OrderTest {
 		//when, then
 		assertThatIllegalArgumentException()
 			  .isThrownBy(() -> order.changeStatus(OrderStatus.MEAL.name()))
-			  .withMessage("결제 완료된 주문은 상태를 변경할 수 없습니다.")
-		;
+			  .withMessage("결제 완료된 주문은 상태를 변경할 수 없습니다.");
 	}
 
 	@DisplayName("비어있는 테이블은 주문을 등록할 수 없음")
@@ -29,20 +26,7 @@ class OrderTest {
 	void createWithEmptyTable() {
 		//when, then
 		assertThatIllegalArgumentException()
-			  .isThrownBy(() -> new Orders(new OrderTable(true), OrderStatus.COOKING.name(),
-					Arrays.asList(new OrderLineItem())))
-			  .withMessage("테이블이 비어있습니다.")
-		;
-	}
-
-	@DisplayName("주문항목이 비어있는 경우 주문을 등록할 수 없음")
-	@Test
-	void createWithEmptyOrderLineItems() {
-		//when, then
-		assertThatIllegalArgumentException()
-			  .isThrownBy(() -> new Orders(new OrderTable(false), OrderStatus.COOKING.name(),
-					new ArrayList<>()))
-			  .withMessage("주문 항목이 비어있습니다.")
-		;
+			  .isThrownBy(() -> new Orders(new OrderTable(true), OrderStatus.COOKING.name()))
+			  .withMessage("테이블이 비어있습니다.");
 	}
 }

--- a/src/test/java/kitchenpos/order/ui/OrderAcceptanceTest.java
+++ b/src/test/java/kitchenpos/order/ui/OrderAcceptanceTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-class OrdersAcceptanceTest extends AcceptanceTest {
+class OrderAcceptanceTest extends AcceptanceTest {
 
 	@DisplayName("주문정보를 관리한다")
 	@Test
@@ -72,13 +72,12 @@ class OrdersAcceptanceTest extends AcceptanceTest {
 	}
 
 	private ExtractableResponse<Response> 주문_목록을_조회한다() {
-		ExtractableResponse<Response> listResponse = RestAssured.given().log().all()
+		return RestAssured.given().log().all()
 			  .contentType(MediaType.APPLICATION_JSON_VALUE)
 			  .when().get("/api/orders/")
 			  .then().log().all()
 			  .statusCode(HttpStatus.OK.value())
 			  .extract();
-		return listResponse;
 	}
 
 	private void 주문정보가_등록됨(ExtractableResponse<Response> response) {

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
@@ -3,9 +3,6 @@ package kitchenpos.ordertable.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-import java.util.Arrays;
-import kitchenpos.order.domain.OrderStatus;
-import kitchenpos.order.domain.Orders;
 import kitchenpos.tablegroup.domain.TableGroup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +17,7 @@ class OrderTableTest {
 		OrderTable orderTable = new OrderTable(false);
 
 		//when
-		orderTable.changeEmpty(true);
+		orderTable.changeEmpty(true, true);
 
 		//then
 		assertThat(orderTable.isEmpty()).isTrue();
@@ -30,15 +27,13 @@ class OrderTableTest {
 	@Test
 	void changeEmptyWithGroupTable() {
 		//given
-		OrderTables orderTables = new OrderTables(
-			  Arrays.asList(new OrderTable(false), new OrderTable(false)), 2);
-		TableGroup tableGroup = new TableGroup(orderTables);
+		TableGroup tableGroup = TableGroup.newInstance();
 		ReflectionTestUtils.setField(tableGroup, "id", 1L);
 		OrderTable orderTable = new OrderTable(1, false, tableGroup);
 
 		//when, then
 		assertThatIllegalArgumentException()
-			  .isThrownBy(() -> orderTable.changeEmpty(true))
+			  .isThrownBy(() -> orderTable.changeEmpty(true, true))
 			  .withMessage("단체 지정된 테이블은 상태를 변경할 수 없습니다.");
 	}
 
@@ -46,13 +41,11 @@ class OrderTableTest {
 	@Test
 	void changeEmptyWithNotCompleteOrder() {
 		//given
-		Orders orders = new Orders(OrderStatus.MEAL.name());
 		OrderTable orderTable = new OrderTable();
-		ReflectionTestUtils.setField(orderTable, "orders", Arrays.asList(orders));
 
 		//when, then
 		assertThatIllegalArgumentException()
-			  .isThrownBy(() -> orderTable.changeEmpty(true))
+			  .isThrownBy(() -> orderTable.changeEmpty(true, false))
 			  .withMessage("조리, 식사 상태의 테이블은 상태를 변경할 수 없습니다.");
 	}
 
@@ -60,9 +53,7 @@ class OrderTableTest {
 	@Test
 	void changeNumberOfGuests() {
 		//given
-		OrderTables orderTables = new OrderTables(
-			  Arrays.asList(new OrderTable(false), new OrderTable(false)), 2);
-		TableGroup tableGroup = new TableGroup(orderTables);
+		TableGroup tableGroup = TableGroup.newInstance();
 		ReflectionTestUtils.setField(tableGroup, "id", 1L);
 		OrderTable orderTable = new OrderTable(0, false, tableGroup);
 
@@ -78,9 +69,7 @@ class OrderTableTest {
 	@Test
 	void changeNumberOfGuestsWithWrongGuestNumber() {
 		//given
-		OrderTables orderTables = new OrderTables(
-			  Arrays.asList(new OrderTable(false), new OrderTable(false)), 2);
-		TableGroup tableGroup = new TableGroup(orderTables);
+		TableGroup tableGroup = TableGroup.newInstance();
 		ReflectionTestUtils.setField(tableGroup, "id", 1L);
 		OrderTable orderTable = new OrderTable(0, false, tableGroup);
 
@@ -94,9 +83,7 @@ class OrderTableTest {
 	@Test
 	void changeNumberOfGuestsWithEmptyTable() {
 		//given
-		OrderTables orderTables = new OrderTables(
-			  Arrays.asList(new OrderTable(false), new OrderTable(false)), 2);
-		TableGroup tableGroup = new TableGroup(orderTables);
+		TableGroup tableGroup = TableGroup.newInstance();
 		ReflectionTestUtils.setField(tableGroup, "id", 1L);
 		OrderTable orderTable = new OrderTable(0, true, tableGroup);
 

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTablesTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTablesTest.java
@@ -29,10 +29,7 @@ class OrderTablesTest {
 	@DisplayName("다른 단체에 포함된 테이블은 단체 지정을 할 수 없음")
 	@Test
 	void createWithOtherTableGroup() {
-		OrderTables orderTables = new OrderTables(
-			  Arrays.asList(new OrderTable(false), new OrderTable(false)), 2);
-		TableGroup tableGroup = new TableGroup(orderTables);
-
+		TableGroup tableGroup = TableGroup.newInstance();
 		OrderTable otherGroupTable = new OrderTable();
 		ReflectionTestUtils.setField(otherGroupTable, "tableGroup", tableGroup);
 


### PR DESCRIPTION
안녕하세요 피드백부탁드립니다.

* Entity 양방향 연관관계 -> 단방향으로 변경 ( ManyToOne 에서 관리하도록 변경 )
* 리팩토링과정에서 Service간 순환참조가 발생하여 repository 접근용 서비스 분리  ( *QueryService )

* 엔티티 관계
![image](https://user-images.githubusercontent.com/34908960/104868530-f2448a80-5986-11eb-92e1-fc9de69375a7.png)

* 서비스 레이어 관계
![image](https://user-images.githubusercontent.com/34908960/104868541-f7093e80-5986-11eb-947d-1fd961f06789.png)
