### PR TITLE
3단계 - 의존성 리팩터링

### DIFF
--- a/src/main/java/kitchenpos/common/domain/Name.java
+++ b/src/main/java/kitchenpos/common/domain/Name.java
@@ -11,7 +11,7 @@ public class Name extends Value<Name> {
 	protected Name() {
 	}
 
-	public static Name of(String value) {
+	public static Name from(String value) {
 		if (value == null || value.isEmpty()) {
 			throw new IllegalArgumentException("이름은 빈 값일 수 없습니다.");
 		}

--- a/src/main/java/kitchenpos/common/domain/Price.java
+++ b/src/main/java/kitchenpos/common/domain/Price.java
@@ -35,4 +35,8 @@ public class Price extends Value<Price> {
 	public Price add(Price price) {
 		return from(value.add(price.value));
 	}
+
+	public Price multiply(Quantity quantity) {
+		return from(value.multiply(BigDecimal.valueOf(quantity.getValue())));
+	}
 }

--- a/src/main/java/kitchenpos/common/domain/Price.java
+++ b/src/main/java/kitchenpos/common/domain/Price.java
@@ -14,7 +14,7 @@ public class Price extends Value<Price> {
 
 	}
 
-	public static Price of(BigDecimal value) {
+	public static Price from(BigDecimal value) {
 		if (value == null || value.compareTo(BigDecimal.ZERO) < 0) {
 			throw new IllegalArgumentException("가격은 0 이상이어야 합니다.");
 		}

--- a/src/main/java/kitchenpos/common/domain/Price.java
+++ b/src/main/java/kitchenpos/common/domain/Price.java
@@ -31,4 +31,8 @@ public class Price extends Value<Price> {
 	public int compareTo(Price price) {
 		return value.compareTo(price.value);
 	}
+
+	public Price add(Price price) {
+		return from(value.add(price.value));
+	}
 }

--- a/src/main/java/kitchenpos/common/domain/Quantity.java
+++ b/src/main/java/kitchenpos/common/domain/Quantity.java
@@ -11,14 +11,14 @@ public class Quantity extends Value<Quantity> {
 	protected Quantity() {
 	}
 
-	public static Quantity from(Long quantity) {
-		if (quantity == null || quantity < 0) {
+	public static Quantity from(Long value) {
+		if (value == null || value < 0) {
 			throw new IllegalArgumentException("수량은 0 이상이어야 합니다.");
 		}
 
-		Quantity menuProductQuantity = new Quantity();
-		menuProductQuantity.value = quantity;
-		return menuProductQuantity;
+		Quantity quantity = new Quantity();
+		quantity.value = value;
+		return quantity;
 	}
 
 	public long getValue() {

--- a/src/main/java/kitchenpos/common/domain/Quantity.java
+++ b/src/main/java/kitchenpos/common/domain/Quantity.java
@@ -11,7 +11,7 @@ public class Quantity extends Value<Quantity> {
 	protected Quantity() {
 	}
 
-	public static Quantity of(Long quantity) {
+	public static Quantity from(Long quantity) {
 		if (quantity == null || quantity < 0) {
 			throw new IllegalArgumentException("수량은 0 이상이어야 합니다.");
 		}

--- a/src/main/java/kitchenpos/menu/application/MenuService.java
+++ b/src/main/java/kitchenpos/menu/application/MenuService.java
@@ -9,46 +9,31 @@ import org.springframework.transaction.annotation.Transactional;
 import kitchenpos.common.domain.Name;
 import kitchenpos.common.domain.Price;
 import kitchenpos.menu.domain.Menu;
-import kitchenpos.menu.domain.MenuProduct;
-import kitchenpos.common.domain.Quantity;
-import kitchenpos.menu.domain.MenuProducts;
 import kitchenpos.menu.domain.MenuRepository;
+import kitchenpos.menu.domain.MenuValidator;
 import kitchenpos.menu.dto.MenuCreateRequest;
 import kitchenpos.menu.dto.MenuDto;
-import kitchenpos.menu.dto.MenuProductDto;
-import kitchenpos.menugroup.domain.MenuGroup;
-import kitchenpos.menugroup.domain.MenuGroupRepository;
-import kitchenpos.product.domain.Product;
-import kitchenpos.product.domain.ProductRepository;
 
 @Service
 @Transactional(readOnly = true)
 public class MenuService {
 	private final MenuRepository menuRepository;
-	private final MenuGroupRepository menuGroupRepository;
-	private final ProductRepository productRepository;
+	private final MenuValidator menuValidator;
 
-	public MenuService(
-		MenuRepository menuRepository,
-		MenuGroupRepository menuGroupRepository,
-		ProductRepository productRepository
-	) {
+	public MenuService(MenuRepository menuRepository, MenuValidator menuValidator) {
 		this.menuRepository = menuRepository;
-		this.menuGroupRepository = menuGroupRepository;
-		this.productRepository = productRepository;
+		this.menuValidator = menuValidator;
 	}
 
 	@Transactional
-	public MenuDto create(final MenuCreateRequest request) {
-		Name name = Name.from(request.getName());
-		Price price = Price.from(request.getPrice());
-		MenuGroup menuGroup = menuGroupRepository.findById(request.getMenuGroupId())
-			.orElseThrow(IllegalArgumentException::new);
-		MenuProducts menuProducts = MenuProducts.from(request.getMenuProducts()
-			.stream()
-			.map(this::findMenuProduct)
-			.collect(Collectors.toList()));
-		Menu menu = menuRepository.save(Menu.of(name, price, menuGroup.getId(), menuProducts));
+	public MenuDto create(MenuCreateRequest request) {
+		Menu menu = menuRepository.save(
+			Menu.of(
+				Name.from(request.getName()),
+				Price.from(request.getPrice()),
+				request.getMenuGroupId(),
+				request.getMenuProducts(),
+				menuValidator));
 		return MenuDto.from(menu);
 	}
 
@@ -57,12 +42,5 @@ public class MenuService {
 		return menus.stream()
 			.map(MenuDto::from)
 			.collect(Collectors.toList());
-	}
-
-	private MenuProduct findMenuProduct(MenuProductDto menuProductDto) {
-		Product product = productRepository.findById(menuProductDto.getProductId())
-			.orElseThrow(IllegalArgumentException::new);
-		Quantity quantity = Quantity.from(menuProductDto.getQuantity());
-		return MenuProduct.of(product, quantity);
 	}
 }

--- a/src/main/java/kitchenpos/menu/application/MenuService.java
+++ b/src/main/java/kitchenpos/menu/application/MenuService.java
@@ -40,29 +40,29 @@ public class MenuService {
 
 	@Transactional
 	public MenuDto create(final MenuCreateRequest request) {
-		Name name = Name.of(request.getName());
-		Price price = Price.of(request.getPrice());
+		Name name = Name.from(request.getName());
+		Price price = Price.from(request.getPrice());
 		MenuGroup menuGroup = menuGroupRepository.findById(request.getMenuGroupId())
 			.orElseThrow(IllegalArgumentException::new);
-		MenuProducts menuProducts = MenuProducts.of(request.getMenuProducts()
+		MenuProducts menuProducts = MenuProducts.from(request.getMenuProducts()
 			.stream()
 			.map(this::findMenuProduct)
 			.collect(Collectors.toList()));
 		Menu menu = menuRepository.save(Menu.of(name, price, menuGroup, menuProducts));
-		return MenuDto.of(menu);
+		return MenuDto.from(menu);
 	}
 
 	public List<MenuDto> list() {
 		List<Menu> menus = menuRepository.findAll();
 		return menus.stream()
-			.map(MenuDto::of)
+			.map(MenuDto::from)
 			.collect(Collectors.toList());
 	}
 
 	private MenuProduct findMenuProduct(MenuProductDto menuProductDto) {
 		Product product = productRepository.findById(menuProductDto.getProductId())
 			.orElseThrow(IllegalArgumentException::new);
-		Quantity quantity = Quantity.of(menuProductDto.getQuantity());
+		Quantity quantity = Quantity.from(menuProductDto.getQuantity());
 		return MenuProduct.of(product, quantity);
 	}
 }

--- a/src/main/java/kitchenpos/menu/application/MenuService.java
+++ b/src/main/java/kitchenpos/menu/application/MenuService.java
@@ -48,7 +48,7 @@ public class MenuService {
 			.stream()
 			.map(this::findMenuProduct)
 			.collect(Collectors.toList()));
-		Menu menu = menuRepository.save(Menu.of(name, price, menuGroup, menuProducts));
+		Menu menu = menuRepository.save(Menu.of(name, price, menuGroup.getId(), menuProducts));
 		return MenuDto.from(menu);
 	}
 

--- a/src/main/java/kitchenpos/menu/domain/Menu.java
+++ b/src/main/java/kitchenpos/menu/domain/Menu.java
@@ -5,13 +5,10 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import kitchenpos.common.domain.Name;
 import kitchenpos.common.domain.Price;
-import kitchenpos.menugroup.domain.MenuGroup;
 
 @Table(name = "menu")
 @Entity
@@ -26,9 +23,7 @@ public class Menu {
 	@Embedded
 	private Price price;
 
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "menu_group_id")
-	private MenuGroup menuGroup;
+	private Long menuGroupId;
 
 	@Embedded
 	private MenuProducts menuProducts;
@@ -36,13 +31,13 @@ public class Menu {
 	protected Menu() {
 	}
 
-	public static Menu of(Name name, Price price, MenuGroup menuGroup, MenuProducts menuProducts) {
+	public static Menu of(Name name, Price price, Long menuGroupId, MenuProducts menuProducts) {
 		throwOnPriceInvalid(price, menuProducts);
 
 		Menu menu = new Menu();
 		menu.name = name;
 		menu.price = price;
-		menu.menuGroup = menuGroup;
+		menu.menuGroupId = menuGroupId;
 		menu.menuProducts = menuProducts;
 		return menu;
 	}
@@ -65,8 +60,8 @@ public class Menu {
 		return price;
 	}
 
-	public MenuGroup getMenuGroup() {
-		return menuGroup;
+	public Long getMenuGroupId() {
+		return menuGroupId;
 	}
 
 	public MenuProducts getMenuProducts() {

--- a/src/main/java/kitchenpos/menu/domain/Menu.java
+++ b/src/main/java/kitchenpos/menu/domain/Menu.java
@@ -1,5 +1,8 @@
 package kitchenpos.menu.domain;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -9,6 +12,8 @@ import javax.persistence.Table;
 
 import kitchenpos.common.domain.Name;
 import kitchenpos.common.domain.Price;
+import kitchenpos.common.domain.Quantity;
+import kitchenpos.menu.dto.MenuProductDto;
 
 @Table(name = "menu")
 @Entity
@@ -31,21 +36,46 @@ public class Menu {
 	protected Menu() {
 	}
 
-	public static Menu of(Name name, Price price, Long menuGroupId, MenuProducts menuProducts) {
-		throwOnPriceInvalid(price, menuProducts);
+	private Menu(
+		Long id,
+		Name name,
+		Price price,
+		Long menuGroupId,
+		List<MenuProductDto> menuProductDtos,
+		MenuValidator validator
+	) {
+		validator.validateMenuGroupExist(menuGroupId);
+		validator.validateProductsExist(menuProductDtos);
+		validator.validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPrice(price, menuProductDtos);
 
-		Menu menu = new Menu();
-		menu.name = name;
-		menu.price = price;
-		menu.menuGroupId = menuGroupId;
-		menu.menuProducts = menuProducts;
-		return menu;
+		this.id = id;
+		this.name = name;
+		this.price = price;
+		this.menuGroupId = menuGroupId;
+		this.menuProducts = MenuProducts.from(menuProductDtos.stream()
+			.map(dto -> MenuProduct.of(dto.getProductId(), Quantity.from(dto.getQuantity())))
+			.collect(Collectors.toList()));
 	}
 
-	private static void throwOnPriceInvalid(Price price, MenuProducts menuProducts) {
-		if (price.compareTo(menuProducts.getTotalPrice()) > 0) {
-			throw new IllegalArgumentException("메뉴의 가격은 메뉴상품들의 전체 가격보다 적거나 같아야 합니다.");
-		}
+	public static Menu of(
+		Long id,
+		Name name,
+		Price price,
+		Long menuGroupId,
+		List<MenuProductDto> menuProductDtos,
+		MenuValidator validator
+	) {
+		return new Menu(id, name, price, menuGroupId, menuProductDtos, validator);
+	}
+
+	public static Menu of(
+		Name name,
+		Price price,
+		Long menuGroupId,
+		List<MenuProductDto> menuProductDtos,
+		MenuValidator validator
+	) {
+		return new Menu(null, name, price, menuGroupId, menuProductDtos, validator);
 	}
 
 	public Long getId() {

--- a/src/main/java/kitchenpos/menu/domain/MenuGroups.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuGroups.java
@@ -1,0 +1,5 @@
+package kitchenpos.menu.domain;
+
+public interface MenuGroups {
+	boolean contains(Long id);
+}

--- a/src/main/java/kitchenpos/menu/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProduct.java
@@ -1,5 +1,7 @@
 package kitchenpos.menu.domain;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -9,6 +11,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import kitchenpos.common.domain.Price;
 import kitchenpos.common.domain.Quantity;
 import kitchenpos.product.domain.Product;
 
@@ -46,5 +49,11 @@ public class MenuProduct {
 
 	public Quantity getQuantity() {
 		return quantity;
+	}
+
+	public Price getTotalPrice() {
+		BigDecimal price = product.getPrice().getValue();
+		BigDecimal quantity = BigDecimal.valueOf(getQuantity().getValue());
+		return Price.from(price.multiply(quantity));
 	}
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProduct.java
@@ -1,19 +1,13 @@
 package kitchenpos.menu.domain;
 
-import java.math.BigDecimal;
-
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import kitchenpos.common.domain.Price;
 import kitchenpos.common.domain.Quantity;
-import kitchenpos.product.domain.Product;
 
 @Table(name = "menu_product")
 @Entity
@@ -22,9 +16,7 @@ public class MenuProduct {
 	@Id
 	private Long seq;
 
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "product_id")
-	private Product product;
+	private Long productId;
 
 	@Embedded
 	private Quantity quantity;
@@ -32,9 +24,17 @@ public class MenuProduct {
 	protected MenuProduct() {
 	}
 
-	public static MenuProduct of(Product product, Quantity quantity) {
+	public static MenuProduct of(Long seq, Long productId, Quantity quantity) {
 		MenuProduct menuProduct = new MenuProduct();
-		menuProduct.product = product;
+		menuProduct.seq = seq;
+		menuProduct.productId = productId;
+		menuProduct.quantity = quantity;
+		return menuProduct;
+	}
+
+	public static MenuProduct of(Long productId, Quantity quantity) {
+		MenuProduct menuProduct = new MenuProduct();
+		menuProduct.productId = productId;
 		menuProduct.quantity = quantity;
 		return menuProduct;
 	}
@@ -43,17 +43,11 @@ public class MenuProduct {
 		return seq;
 	}
 
-	public Product getProduct() {
-		return product;
+	public Long getProductId() {
+		return productId;
 	}
 
 	public Quantity getQuantity() {
 		return quantity;
-	}
-
-	public Price getTotalPrice() {
-		BigDecimal price = product.getPrice().getValue();
-		BigDecimal quantity = BigDecimal.valueOf(getQuantity().getValue());
-		return Price.from(price.multiply(quantity));
 	}
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuProducts.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProducts.java
@@ -1,6 +1,5 @@
 package kitchenpos.menu.domain;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,13 +35,8 @@ public class MenuProducts {
 
 	public Price getTotalPrice() {
 		return values.stream()
-			.map(menuProduct -> {
-				BigDecimal price = menuProduct.getProduct().getPrice().getValue();
-				BigDecimal quantity = BigDecimal.valueOf(menuProduct.getQuantity().getValue());
-				return price.multiply(quantity);
-			})
-			.reduce(BigDecimal::add)
-			.map(Price::from)
+			.map(MenuProduct::getTotalPrice)
+			.reduce(Price::add)
 			.get();
 	}
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuProducts.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProducts.java
@@ -20,7 +20,7 @@ public class MenuProducts {
 	protected MenuProducts() {
 	}
 
-	public static MenuProducts of(List<MenuProduct> values) {
+	public static MenuProducts from(List<MenuProduct> values) {
 		if (values == null || values.isEmpty()) {
 			throw new IllegalArgumentException("메뉴 상품들은 한개 이상이어야 합니다.");
 		}
@@ -42,7 +42,7 @@ public class MenuProducts {
 				return price.multiply(quantity);
 			})
 			.reduce(BigDecimal::add)
-			.map(Price::of)
+			.map(Price::from)
 			.get();
 	}
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuProducts.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProducts.java
@@ -8,8 +8,6 @@ import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 
-import kitchenpos.common.domain.Price;
-
 @Embeddable
 public class MenuProducts {
 	@OneToMany(cascade = CascadeType.ALL)
@@ -33,10 +31,7 @@ public class MenuProducts {
 		return values;
 	}
 
-	public Price getTotalPrice() {
-		return values.stream()
-			.map(MenuProduct::getTotalPrice)
-			.reduce(Price::add)
-			.get();
+	public int size() {
+		return values.size();
 	}
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuRepository.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuRepository.java
@@ -9,4 +9,6 @@ public interface MenuRepository {
 	Menu save(Menu menu);
 
 	Optional<Menu> findById(Long id);
+
+	List<Menu> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuValidator.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuValidator.java
@@ -1,0 +1,14 @@
+package kitchenpos.menu.domain;
+
+import java.util.List;
+
+import kitchenpos.common.domain.Price;
+import kitchenpos.menu.dto.MenuProductDto;
+
+public interface MenuValidator {
+	void validateMenuGroupExist(Long menuGroupId);
+
+	void validateProductsExist(List<MenuProductDto> menuProductDto);
+
+	void validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPrice(Price price, List<MenuProductDto> menuProductDto);
+}

--- a/src/main/java/kitchenpos/menu/domain/MenuValidatorImpl.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuValidatorImpl.java
@@ -1,0 +1,57 @@
+package kitchenpos.menu.domain;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.common.domain.Price;
+import kitchenpos.common.domain.Quantity;
+import kitchenpos.menu.dto.MenuProductDto;
+
+@Component
+public class MenuValidatorImpl implements MenuValidator {
+	private final MenuGroups menuGroups;
+	private final Products products;
+
+	public MenuValidatorImpl(MenuGroups menuGroups, Products products) {
+		this.menuGroups = menuGroups;
+		this.products = products;
+	}
+
+	@Override
+	public void validateMenuGroupExist(Long menuGroupId) {
+		if (!menuGroups.contains(menuGroupId)) {
+			throw new IllegalArgumentException("메뉴 그룹이 존재하지 않습니다.");
+		}
+	}
+
+	@Override
+	public void validateProductsExist(List<MenuProductDto> menuProductDto) {
+		List<Long> productIds = menuProductDto
+			.stream()
+			.map(MenuProductDto::getProductId)
+			.collect(Collectors.toList());
+
+		if (!products.containsAll(productIds)) {
+			throw new IllegalArgumentException("상품이 존재하지 않습니다.");
+		}
+	}
+
+	@Override
+	public void validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPrice(
+		Price menuPrice,
+		List<MenuProductDto> menuProductDto
+	) {
+		Price menuProductsTotalPrice = menuProductDto.stream().map(dto -> {
+				Product product = products.findById(dto.getProductId());
+				Quantity quantity = Quantity.from(dto.getQuantity());
+				return product.getPrice().multiply(quantity);
+			}).reduce(Price::add)
+			.get();
+
+		if (menuPrice.compareTo(menuProductsTotalPrice) > 0) {
+			throw new IllegalArgumentException("메뉴의 가격은 메뉴상품들의 전체 가격보다 적거나 같아야 합니다.");
+		}
+	}
+}

--- a/src/main/java/kitchenpos/menu/domain/Product.java
+++ b/src/main/java/kitchenpos/menu/domain/Product.java
@@ -1,0 +1,22 @@
+package kitchenpos.menu.domain;
+
+import java.math.BigDecimal;
+
+import kitchenpos.common.domain.Price;
+
+public class Product {
+	private Price price;
+
+	private Product() {
+	}
+
+	public static Product from(BigDecimal price) {
+		Product product = new Product();
+		product.price = Price.from(price);
+		return product;
+	}
+
+	public Price getPrice() {
+		return price;
+	}
+}

--- a/src/main/java/kitchenpos/menu/domain/Products.java
+++ b/src/main/java/kitchenpos/menu/domain/Products.java
@@ -1,0 +1,9 @@
+package kitchenpos.menu.domain;
+
+import java.util.List;
+
+public interface Products {
+	boolean containsAll(List<Long> ids);
+
+	Product findById(Long id);
+}

--- a/src/main/java/kitchenpos/menu/dto/MenuDto.java
+++ b/src/main/java/kitchenpos/menu/dto/MenuDto.java
@@ -49,7 +49,7 @@ public class MenuDto {
 		dto.id = menu.getId();
 		dto.name = menu.getName().getValue();
 		dto.price = menu.getPrice().getValue();
-		dto.menuGroupId = menu.getMenuGroup().getId();
+		dto.menuGroupId = menu.getMenuGroupId();
 		dto.menuProducts = menu.getMenuProducts()
 			.getValues()
 			.stream()

--- a/src/main/java/kitchenpos/menu/dto/MenuDto.java
+++ b/src/main/java/kitchenpos/menu/dto/MenuDto.java
@@ -44,7 +44,7 @@ public class MenuDto {
 		return menuProducts;
 	}
 
-	public static MenuDto of(Menu menu) {
+	public static MenuDto from(Menu menu) {
 		MenuDto dto = new MenuDto();
 		dto.id = menu.getId();
 		dto.name = menu.getName().getValue();
@@ -53,7 +53,7 @@ public class MenuDto {
 		dto.menuProducts = menu.getMenuProducts()
 			.getValues()
 			.stream()
-			.map(MenuProductDto::of)
+			.map(MenuProductDto::from)
 			.collect(Collectors.toList());
 		return dto;
 	}

--- a/src/main/java/kitchenpos/menu/dto/MenuProductDto.java
+++ b/src/main/java/kitchenpos/menu/dto/MenuProductDto.java
@@ -28,7 +28,7 @@ public class MenuProductDto {
 		return quantity;
 	}
 
-	public static MenuProductDto of(MenuProduct menuProduct) {
+	public static MenuProductDto from(MenuProduct menuProduct) {
 		MenuProductDto dto = new MenuProductDto();
 		dto.seq = menuProduct.getSeq();
 		dto.productId = menuProduct.getProduct().getId();

--- a/src/main/java/kitchenpos/menu/dto/MenuProductDto.java
+++ b/src/main/java/kitchenpos/menu/dto/MenuProductDto.java
@@ -10,6 +10,11 @@ public class MenuProductDto {
 	public MenuProductDto() {
 	}
 
+	public MenuProductDto(Long productId, long quantity) {
+		this.productId = productId;
+		this.quantity = quantity;
+	}
+
 	public MenuProductDto(Long seq, Long productId, long quantity) {
 		this.seq = seq;
 		this.productId = productId;
@@ -31,7 +36,7 @@ public class MenuProductDto {
 	public static MenuProductDto from(MenuProduct menuProduct) {
 		MenuProductDto dto = new MenuProductDto();
 		dto.seq = menuProduct.getSeq();
-		dto.productId = menuProduct.getProduct().getId();
+		dto.productId = menuProduct.getProductId();
 		dto.quantity = menuProduct.getQuantity().getValue();
 		return dto;
 	}

--- a/src/main/java/kitchenpos/menu/infra/MenuGroupsImpl.java
+++ b/src/main/java/kitchenpos/menu/infra/MenuGroupsImpl.java
@@ -1,0 +1,20 @@
+package kitchenpos.menu.infra;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.menu.domain.MenuGroups;
+import kitchenpos.menugroup.domain.MenuGroupRepository;
+
+@Component
+public class MenuGroupsImpl implements MenuGroups {
+	private final MenuGroupRepository menuGroupRepository;
+
+	public MenuGroupsImpl(MenuGroupRepository menuGroupRepository) {
+		this.menuGroupRepository = menuGroupRepository;
+	}
+
+	@Override
+	public boolean contains(Long id) {
+		return menuGroupRepository.findById(id).isPresent();
+	}
+}

--- a/src/main/java/kitchenpos/menu/infra/ProductsImpl.java
+++ b/src/main/java/kitchenpos/menu/infra/ProductsImpl.java
@@ -1,0 +1,31 @@
+package kitchenpos.menu.infra;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.menu.domain.Products;
+import kitchenpos.product.domain.Product;
+import kitchenpos.product.domain.ProductRepository;
+
+@Component
+public class ProductsImpl implements Products {
+	private final ProductRepository productRepository;
+
+	public ProductsImpl(ProductRepository productRepository) {
+		this.productRepository = productRepository;
+	}
+
+	@Override
+	public boolean containsAll(List<Long> ids) {
+		List<Product> products = productRepository.findAllByIdIn(ids);
+		return products.size() == ids.size();
+	}
+
+	@Override
+	public kitchenpos.menu.domain.Product findById(Long id) {
+		Product product = productRepository.findById(id).orElseThrow(NoSuchElementException::new);
+		return kitchenpos.menu.domain.Product.from(product.getPrice().getValue());
+	}
+}

--- a/src/main/java/kitchenpos/menugroup/application/MenuGroupService.java
+++ b/src/main/java/kitchenpos/menugroup/application/MenuGroupService.java
@@ -23,14 +23,14 @@ public class MenuGroupService {
 	@Transactional
 	public MenuGroupDto create(MenuGroupCreateRequest request) {
 		MenuGroup menuGroup = menuGroupRepository.save(request.toMenuGroup());
-		return MenuGroupDto.of(menuGroup);
+		return MenuGroupDto.from(menuGroup);
 	}
 
 	public List<MenuGroupDto> list() {
 		List<MenuGroup> menuGroups = menuGroupRepository.findAll();
 
 		return menuGroups.stream()
-			.map(MenuGroupDto::of)
+			.map(MenuGroupDto::from)
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/kitchenpos/menugroup/domain/MenuGroup.java
+++ b/src/main/java/kitchenpos/menugroup/domain/MenuGroup.java
@@ -22,10 +22,17 @@ public class MenuGroup {
 	protected MenuGroup() {
 	}
 
+	private MenuGroup(Long id, Name name) {
+		this.id = id;
+		this.name = name;
+	}
+
 	public static MenuGroup from(Name name) {
-		MenuGroup menuGroup = new MenuGroup();
-		menuGroup.name = name;
-		return menuGroup;
+		return new MenuGroup(null, name);
+	}
+
+	public static MenuGroup of(Long id, Name name) {
+		return new MenuGroup(id, name);
 	}
 
 	public Long getId() {

--- a/src/main/java/kitchenpos/menugroup/domain/MenuGroup.java
+++ b/src/main/java/kitchenpos/menugroup/domain/MenuGroup.java
@@ -22,7 +22,7 @@ public class MenuGroup {
 	protected MenuGroup() {
 	}
 
-	public static MenuGroup of(Name name) {
+	public static MenuGroup from(Name name) {
 		MenuGroup menuGroup = new MenuGroup();
 		menuGroup.name = name;
 		return menuGroup;

--- a/src/main/java/kitchenpos/menugroup/dto/MenuGroupCreateRequest.java
+++ b/src/main/java/kitchenpos/menugroup/dto/MenuGroupCreateRequest.java
@@ -22,7 +22,7 @@ public class MenuGroupCreateRequest {
 	}
 
 	public MenuGroup toMenuGroup() {
-		Name name = Name.of(this.name);
-		return MenuGroup.of(name);
+		Name name = Name.from(this.name);
+		return MenuGroup.from(name);
 	}
 }

--- a/src/main/java/kitchenpos/menugroup/dto/MenuGroupDto.java
+++ b/src/main/java/kitchenpos/menugroup/dto/MenuGroupDto.java
@@ -14,7 +14,7 @@ public class MenuGroupDto {
 		this.name = name;
 	}
 
-	public static MenuGroupDto of(MenuGroup menuGroup) {
+	public static MenuGroupDto from(MenuGroup menuGroup) {
 		MenuGroupDto dto = new MenuGroupDto();
 		dto.id = menuGroup.getId();
 		dto.name = menuGroup.getName().getValue();

--- a/src/main/java/kitchenpos/order/application/OrderService.java
+++ b/src/main/java/kitchenpos/order/application/OrderService.java
@@ -6,52 +6,30 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import kitchenpos.common.domain.Quantity;
-import kitchenpos.menu.domain.Menu;
-import kitchenpos.menu.domain.MenuRepository;
 import kitchenpos.order.domain.Order;
-import kitchenpos.order.domain.OrderLineItem;
-import kitchenpos.order.domain.OrderLineItems;
 import kitchenpos.order.domain.OrderRepository;
+import kitchenpos.order.domain.OrderValidator;
 import kitchenpos.order.dto.OrderDto;
-import kitchenpos.order.dto.OrderLineItemDto;
 import kitchenpos.order.dto.OrderRequest;
-import kitchenpos.ordertable.domain.OrderTable;
-import kitchenpos.ordertable.domain.OrderTableRepository;
 
 @Service
 @Transactional(readOnly = true)
 public class OrderService {
 	private final OrderRepository orderRepository;
-	private final MenuRepository menuRepository;
-	private final OrderTableRepository orderTableRepository;
+	private final OrderValidator orderValidator;
 
-	public OrderService(OrderRepository orderRepository, MenuRepository menuRepository,
-		OrderTableRepository orderTableRepository) {
+	public OrderService(OrderRepository orderRepository, OrderValidator orderValidator) {
 		this.orderRepository = orderRepository;
-		this.menuRepository = menuRepository;
-		this.orderTableRepository = orderTableRepository;
+		this.orderValidator = orderValidator;
 	}
 
 	@Transactional
 	public OrderDto create(OrderRequest request) {
-		OrderTable orderTable = orderTableRepository.findById(request.getOrderTableId())
-			.orElseThrow(IllegalArgumentException::new);
-		OrderLineItems orderLineItems = findOrderLineItems(request.getOrderLineItems());
-		Order order = orderRepository.save(Order.of(orderTable, orderLineItems));
+		Order order = orderRepository.save(Order.of(
+			request.getOrderTableId(),
+			request.getOrderLineItems(),
+			orderValidator));
 		return OrderDto.from(order);
-	}
-
-	private OrderLineItems findOrderLineItems(List<OrderLineItemDto> orderLineItems) {
-		return OrderLineItems.from(
-			orderLineItems
-				.stream()
-				.map(ol -> {
-					Menu menu = menuRepository.findById(ol.getMenuId()).orElseThrow(IllegalArgumentException::new);
-					Quantity quantity = Quantity.from(ol.getQuantity());
-					return OrderLineItem.of(menu, quantity);
-				})
-				.collect(Collectors.toList()));
 	}
 
 	public List<OrderDto> list() {

--- a/src/main/java/kitchenpos/order/application/OrderService.java
+++ b/src/main/java/kitchenpos/order/application/OrderService.java
@@ -39,16 +39,16 @@ public class OrderService {
 			.orElseThrow(IllegalArgumentException::new);
 		OrderLineItems orderLineItems = findOrderLineItems(request.getOrderLineItems());
 		Order order = orderRepository.save(Order.of(orderTable, orderLineItems));
-		return OrderDto.of(order);
+		return OrderDto.from(order);
 	}
 
 	private OrderLineItems findOrderLineItems(List<OrderLineItemDto> orderLineItems) {
-		return OrderLineItems.of(
+		return OrderLineItems.from(
 			orderLineItems
 				.stream()
 				.map(ol -> {
 					Menu menu = menuRepository.findById(ol.getMenuId()).orElseThrow(IllegalArgumentException::new);
-					Quantity quantity = Quantity.of(ol.getQuantity());
+					Quantity quantity = Quantity.from(ol.getQuantity());
 					return OrderLineItem.of(menu, quantity);
 				})
 				.collect(Collectors.toList()));
@@ -57,7 +57,7 @@ public class OrderService {
 	public List<OrderDto> list() {
 		List<Order> orders = orderRepository.findAll();
 		return orders.stream()
-			.map(OrderDto::of)
+			.map(OrderDto::from)
 			.collect(Collectors.toList());
 	}
 
@@ -65,6 +65,6 @@ public class OrderService {
 	public OrderDto changeOrderStatus(Long id, OrderRequest request) {
 		Order order = orderRepository.findById(id).orElseThrow(IllegalArgumentException::new);
 		order.changeOrderStatus(request.getOrderStatus());
-		return OrderDto.of(order);
+		return OrderDto.from(order);
 	}
 }

--- a/src/main/java/kitchenpos/order/domain/Menus.java
+++ b/src/main/java/kitchenpos/order/domain/Menus.java
@@ -1,0 +1,7 @@
+package kitchenpos.order.domain;
+
+import java.util.List;
+
+public interface Menus {
+	boolean containsAll(List<Long> ids);
+}

--- a/src/main/java/kitchenpos/order/domain/OrderLineItem.java
+++ b/src/main/java/kitchenpos/order/domain/OrderLineItem.java
@@ -5,12 +5,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import kitchenpos.common.domain.Quantity;
-import kitchenpos.menu.domain.Menu;
 
 @Table(name = "order_line_item")
 @Entity
@@ -19,9 +16,7 @@ public class OrderLineItem {
 	@Id
 	private Long seq;
 
-	@ManyToOne(optional = false)
-	@JoinColumn(name = "menu_id")
-	private Menu menu;
+	private Long menuId;
 
 	@Embedded
 	private Quantity quantity;
@@ -29,9 +24,17 @@ public class OrderLineItem {
 	protected OrderLineItem() {
 	}
 
-	public static OrderLineItem of(Menu menu, Quantity quantity) {
+	public static OrderLineItem of(Long seq, Long menuId, Quantity quantity) {
 		OrderLineItem orderLineItem = new OrderLineItem();
-		orderLineItem.menu = menu;
+		orderLineItem.seq = seq;
+		orderLineItem.menuId = menuId;
+		orderLineItem.quantity = quantity;
+		return orderLineItem;
+	}
+
+	public static OrderLineItem of(Long menuId, Quantity quantity) {
+		OrderLineItem orderLineItem = new OrderLineItem();
+		orderLineItem.menuId = menuId;
 		orderLineItem.quantity = quantity;
 		return orderLineItem;
 	}
@@ -40,8 +43,8 @@ public class OrderLineItem {
 		return seq;
 	}
 
-	public Menu getMenu() {
-		return menu;
+	public Long getMenuId() {
+		return menuId;
 	}
 
 	public Quantity getQuantity() {

--- a/src/main/java/kitchenpos/order/domain/OrderLineItems.java
+++ b/src/main/java/kitchenpos/order/domain/OrderLineItems.java
@@ -17,7 +17,7 @@ public class OrderLineItems {
 	protected OrderLineItems() {
 	}
 
-	public static OrderLineItems of(List<OrderLineItem> values) {
+	public static OrderLineItems from(List<OrderLineItem> values) {
 		if (values == null || values.isEmpty()) {
 			throw new IllegalArgumentException("주문 항목들은 한개 이상이어야 합니다.");
 		}

--- a/src/main/java/kitchenpos/order/domain/OrderRepository.java
+++ b/src/main/java/kitchenpos/order/domain/OrderRepository.java
@@ -9,4 +9,6 @@ public interface OrderRepository {
 	List<Order> findAll();
 
 	Optional<Order> findById(Long id);
+
+	List<Order> findByOrderTableId(Long orderTableId);
 }

--- a/src/main/java/kitchenpos/order/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/order/domain/OrderTable.java
@@ -1,0 +1,18 @@
+package kitchenpos.order.domain;
+
+public class OrderTable {
+	private boolean empty;
+
+	private OrderTable() {
+	}
+
+	public static OrderTable from(boolean empty) {
+		OrderTable orderTable = new OrderTable();
+		orderTable.empty = empty;
+		return orderTable;
+	}
+
+	public boolean isEmpty() {
+		return empty;
+	}
+}

--- a/src/main/java/kitchenpos/order/domain/OrderTables.java
+++ b/src/main/java/kitchenpos/order/domain/OrderTables.java
@@ -1,0 +1,7 @@
+package kitchenpos.order.domain;
+
+public interface OrderTables {
+	boolean contains(Long id);
+
+	OrderTable findById(Long id);
+}

--- a/src/main/java/kitchenpos/order/domain/OrderValidator.java
+++ b/src/main/java/kitchenpos/order/domain/OrderValidator.java
@@ -1,0 +1,11 @@
+package kitchenpos.order.domain;
+
+import java.util.List;
+
+import kitchenpos.order.dto.OrderLineItemDto;
+
+public interface OrderValidator {
+	void validateOrderTableExistAndNotEmpty(Long orderTableId);
+
+	void validateMenusExist(List<OrderLineItemDto> orderLineItemDtos);
+}

--- a/src/main/java/kitchenpos/order/domain/OrderValidatorImpl.java
+++ b/src/main/java/kitchenpos/order/domain/OrderValidatorImpl.java
@@ -1,0 +1,43 @@
+package kitchenpos.order.domain;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.order.dto.OrderLineItemDto;
+
+@Component
+public class OrderValidatorImpl implements OrderValidator {
+	private final OrderTables orderTables;
+	private final Menus menus;
+
+	public OrderValidatorImpl(OrderTables orderTables, Menus menus) {
+		this.orderTables = orderTables;
+		this.menus = menus;
+	}
+
+	@Override
+	public void validateOrderTableExistAndNotEmpty(Long orderTableId) {
+		if (!orderTables.contains(orderTableId)) {
+			throw new IllegalArgumentException("주문 테이블이 존재하지 않습니다.");
+		}
+
+		OrderTable orderTable = orderTables.findById(orderTableId);
+		if (orderTable.isEmpty()) {
+			throw new IllegalArgumentException("주문 테이블이 비어있으면 주문을 생성할 수 없습니다.");
+		}
+	}
+
+	@Override
+	public void validateMenusExist(List<OrderLineItemDto> orderLineItemDtos) {
+		List<Long> menuIds = orderLineItemDtos
+			.stream()
+			.map(OrderLineItemDto::getMenuId)
+			.collect(Collectors.toList());
+
+		if (!menus.containsAll(menuIds)) {
+			throw new IllegalArgumentException("메뉴가 존재하지 않습니다.");
+		}
+	}
+}

--- a/src/main/java/kitchenpos/order/dto/OrderDto.java
+++ b/src/main/java/kitchenpos/order/dto/OrderDto.java
@@ -26,7 +26,7 @@ public class OrderDto {
 		this.orderLineItems = orderLineItems;
 	}
 
-	public static OrderDto of(Order order) {
+	public static OrderDto from(Order order) {
 		OrderDto dto = new OrderDto();
 		dto.id = order.getId();
 		dto.orderTableId = order.getOrderTable().getId();
@@ -35,7 +35,7 @@ public class OrderDto {
 		dto.orderLineItems = order.getOrderLineItems()
 			.getValues()
 			.stream()
-			.map(OrderLineItemDto::of)
+			.map(OrderLineItemDto::from)
 			.collect(Collectors.toList());
 		return dto;
 	}

--- a/src/main/java/kitchenpos/order/dto/OrderDto.java
+++ b/src/main/java/kitchenpos/order/dto/OrderDto.java
@@ -29,7 +29,7 @@ public class OrderDto {
 	public static OrderDto from(Order order) {
 		OrderDto dto = new OrderDto();
 		dto.id = order.getId();
-		dto.orderTableId = order.getOrderTable().getId();
+		dto.orderTableId = order.getOrderTableId();
 		dto.orderStatus = order.getOrderStatus();
 		dto.orderedTime = order.getOrderedTime();
 		dto.orderLineItems = order.getOrderLineItems()

--- a/src/main/java/kitchenpos/order/dto/OrderLineItemDto.java
+++ b/src/main/java/kitchenpos/order/dto/OrderLineItemDto.java
@@ -30,7 +30,7 @@ public class OrderLineItemDto {
 	public static OrderLineItemDto from(OrderLineItem orderLineItem) {
 		OrderLineItemDto dto = new OrderLineItemDto();
 		dto.seq = orderLineItem.getSeq();
-		dto.menuId = orderLineItem.getMenu().getId();
+		dto.menuId = orderLineItem.getMenuId();
 		dto.quantity = orderLineItem.getQuantity().getValue();
 		return dto;
 	}

--- a/src/main/java/kitchenpos/order/dto/OrderLineItemDto.java
+++ b/src/main/java/kitchenpos/order/dto/OrderLineItemDto.java
@@ -27,7 +27,7 @@ public class OrderLineItemDto {
 		return quantity;
 	}
 
-	public static OrderLineItemDto of(OrderLineItem orderLineItem) {
+	public static OrderLineItemDto from(OrderLineItem orderLineItem) {
 		OrderLineItemDto dto = new OrderLineItemDto();
 		dto.seq = orderLineItem.getSeq();
 		dto.menuId = orderLineItem.getMenu().getId();

--- a/src/main/java/kitchenpos/order/infra/MenusImpl.java
+++ b/src/main/java/kitchenpos/order/infra/MenusImpl.java
@@ -1,0 +1,24 @@
+package kitchenpos.order.infra;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.menu.domain.Menu;
+import kitchenpos.menu.domain.MenuRepository;
+import kitchenpos.order.domain.Menus;
+
+@Component
+public class MenusImpl implements Menus {
+	private final MenuRepository menuRepository;
+
+	public MenusImpl(MenuRepository menuRepository) {
+		this.menuRepository = menuRepository;
+	}
+
+	@Override
+	public boolean containsAll(List<Long> ids) {
+		List<Menu> menus = menuRepository.findAllByIdIn(ids);
+		return menus.size() == ids.size();
+	}
+}

--- a/src/main/java/kitchenpos/order/infra/OrderTablesImpl.java
+++ b/src/main/java/kitchenpos/order/infra/OrderTablesImpl.java
@@ -1,0 +1,27 @@
+package kitchenpos.order.infra;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.order.domain.OrderTables;
+import kitchenpos.ordertable.domain.OrderTable;
+import kitchenpos.ordertable.domain.OrderTableRepository;
+
+@Component
+public class OrderTablesImpl implements OrderTables {
+	private final OrderTableRepository orderTableRepository;
+
+	public OrderTablesImpl(OrderTableRepository orderTableRepository) {
+		this.orderTableRepository = orderTableRepository;
+	}
+
+	@Override
+	public boolean contains(Long id) {
+		return orderTableRepository.findById(id).isPresent();
+	}
+
+	@Override
+	public kitchenpos.order.domain.OrderTable findById(Long id) {
+		OrderTable orderTable = orderTableRepository.findById(id).orElseThrow(NoSuchFieldError::new);
+		return kitchenpos.order.domain.OrderTable.from(orderTable.isEmpty());
+	}
+}

--- a/src/main/java/kitchenpos/ordertable/application/OrderTableGroupingEventHandler.java
+++ b/src/main/java/kitchenpos/ordertable/application/OrderTableGroupingEventHandler.java
@@ -1,0 +1,27 @@
+package kitchenpos.ordertable.application;
+
+import java.util.List;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kitchenpos.ordertable.domain.OrderTable;
+import kitchenpos.ordertable.domain.OrderTableRepository;
+import kitchenpos.ordertablegroup.domain.OrderTableGroupingEvent;
+
+@Component
+public class OrderTableGroupingEventHandler {
+	private final OrderTableRepository orderTableRepository;
+
+	public OrderTableGroupingEventHandler(OrderTableRepository orderTableRepository) {
+		this.orderTableRepository = orderTableRepository;
+	}
+
+	@EventListener
+	@Transactional
+	public void handle(OrderTableGroupingEvent event) {
+		List<OrderTable> orderTables = orderTableRepository.findAllByIdIn(event.getOrderTableIds());
+		orderTables.forEach(orderTable -> orderTable.groupedBy(event.getOrderTableGroupId()));
+	}
+}

--- a/src/main/java/kitchenpos/ordertable/application/OrderTableService.java
+++ b/src/main/java/kitchenpos/ordertable/application/OrderTableService.java
@@ -24,13 +24,13 @@ public class OrderTableService {
 	@Transactional
 	public OrderTableDto create(OrderTableRequest request) {
 		OrderTable orderTable = orderTableRepository.save(request.toOrderTable());
-		return OrderTableDto.of(orderTable);
+		return OrderTableDto.from(orderTable);
 	}
 
 	public List<OrderTableDto> list() {
 		List<OrderTable> orderTables = orderTableRepository.findAll();
 		return orderTables.stream()
-			.map(OrderTableDto::of)
+			.map(OrderTableDto::from)
 			.collect(Collectors.toList());
 	}
 
@@ -38,14 +38,14 @@ public class OrderTableService {
 	public OrderTableDto changeEmpty(Long id, OrderTableRequest request) {
 		OrderTable orderTable = orderTableRepository.findById(id).orElseThrow(IllegalArgumentException::new);
 		orderTable.changeEmpty(request.isEmpty());
-		return OrderTableDto.of(orderTable);
+		return OrderTableDto.from(orderTable);
 	}
 
 	@Transactional
 	public OrderTableDto changeNumberOfGuests(Long id, OrderTableRequest request) {
 		OrderTable orderTable = orderTableRepository.findById(id).orElseThrow(IllegalArgumentException::new);
-		NumberOfGuests numberOfGuests = NumberOfGuests.of(request.getNumberOfGuests());
+		NumberOfGuests numberOfGuests = NumberOfGuests.from(request.getNumberOfGuests());
 		orderTable.changeNumberOfGuests(numberOfGuests);
-		return OrderTableDto.of(orderTable);
+		return OrderTableDto.from(orderTable);
 	}
 }

--- a/src/main/java/kitchenpos/ordertable/application/OrderTableService.java
+++ b/src/main/java/kitchenpos/ordertable/application/OrderTableService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import kitchenpos.ordertable.domain.NumberOfGuests;
 import kitchenpos.ordertable.domain.OrderTable;
 import kitchenpos.ordertable.domain.OrderTableRepository;
+import kitchenpos.ordertable.domain.OrderTableValidator;
 import kitchenpos.ordertable.dto.OrderTableDto;
 import kitchenpos.ordertable.dto.OrderTableRequest;
 
@@ -16,9 +17,14 @@ import kitchenpos.ordertable.dto.OrderTableRequest;
 @Transactional(readOnly = true)
 public class OrderTableService {
 	private final OrderTableRepository orderTableRepository;
+	private final OrderTableValidator orderTableValidator;
 
-	public OrderTableService(OrderTableRepository orderTableRepository) {
+	public OrderTableService(
+		OrderTableRepository orderTableRepository,
+		OrderTableValidator orderTableValidator
+	) {
 		this.orderTableRepository = orderTableRepository;
+		this.orderTableValidator = orderTableValidator;
 	}
 
 	@Transactional
@@ -37,7 +43,7 @@ public class OrderTableService {
 	@Transactional
 	public OrderTableDto changeEmpty(Long id, OrderTableRequest request) {
 		OrderTable orderTable = orderTableRepository.findById(id).orElseThrow(IllegalArgumentException::new);
-		orderTable.changeEmpty(request.isEmpty());
+		orderTable.changeEmpty(request.isEmpty(), orderTableValidator);
 		return OrderTableDto.from(orderTable);
 	}
 

--- a/src/main/java/kitchenpos/ordertable/application/OrderTableUngroupingEventHandler.java
+++ b/src/main/java/kitchenpos/ordertable/application/OrderTableUngroupingEventHandler.java
@@ -1,0 +1,27 @@
+package kitchenpos.ordertable.application;
+
+import java.util.List;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kitchenpos.ordertable.domain.OrderTable;
+import kitchenpos.ordertable.domain.OrderTableRepository;
+import kitchenpos.ordertablegroup.domain.OrderTableUngroupingEvent;
+
+@Component
+public class OrderTableUngroupingEventHandler {
+	private final OrderTableRepository orderTableRepository;
+
+	public OrderTableUngroupingEventHandler(OrderTableRepository orderTableRepository) {
+		this.orderTableRepository = orderTableRepository;
+	}
+
+	@EventListener
+	@Transactional
+	public void handle(OrderTableUngroupingEvent event) {
+		List<OrderTable> orderTables = orderTableRepository.findByOrderTableGroupId(event.getOrderTableGroupId());
+		orderTables.forEach(OrderTable::ungrouped);
+	}
+}

--- a/src/main/java/kitchenpos/ordertable/domain/NumberOfGuests.java
+++ b/src/main/java/kitchenpos/ordertable/domain/NumberOfGuests.java
@@ -13,7 +13,7 @@ public class NumberOfGuests extends Value<NumberOfGuests> {
 	protected NumberOfGuests() {
 	}
 
-	public static NumberOfGuests of(Integer value) {
+	public static NumberOfGuests from(Integer value) {
 		if (value == null || value < 0) {
 			throw new IllegalArgumentException("손님 수는 0보다 같거나 커야 합니다.");
 		}

--- a/src/main/java/kitchenpos/ordertable/domain/Order.java
+++ b/src/main/java/kitchenpos/ordertable/domain/Order.java
@@ -1,0 +1,26 @@
+package kitchenpos.ordertable.domain;
+
+public class Order {
+	private OrderStatus orderStatus;
+
+	private Order() {
+	}
+
+	public static Order from(String orderStatus) {
+		Order order = new Order();
+		order.orderStatus = OrderStatus.valueOf(orderStatus);
+		return order;
+	}
+
+	public OrderStatus getOrderStatus() {
+		return orderStatus;
+	}
+
+	public enum OrderStatus {
+		COOKING, MEAL, COMPLETION;
+
+		public boolean isCompletion() {
+			return this == COMPLETION;
+		}
+	}
+}

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
@@ -1,15 +1,12 @@
 package kitchenpos.ordertable.domain;
 
+import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-
-import kitchenpos.ordertablegroup.domain.OrderTableGroup;
 
 @Table(name = "order_table")
 @Entity
@@ -18,9 +15,8 @@ public class OrderTable {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne
-	@JoinColumn(name = "table_group_id")
-	private OrderTableGroup orderTableGroup;
+	@Column(name = "table_group_id")
+	private Long orderTableGroupId;
 
 	@Embedded
 	private NumberOfGuests numberOfGuests;
@@ -30,9 +26,10 @@ public class OrderTable {
 	protected OrderTable() {
 	}
 
-	public static OrderTable of(Long id, NumberOfGuests numberOfGuests, boolean empty) {
+	public static OrderTable of(Long id, Long orderTableGroupId, NumberOfGuests numberOfGuests, boolean empty) {
 		OrderTable orderTable = new OrderTable();
 		orderTable.id = id;
+		orderTable.orderTableGroupId = orderTableGroupId;
 		orderTable.numberOfGuests = numberOfGuests;
 		orderTable.empty = empty;
 		return orderTable;
@@ -49,16 +46,8 @@ public class OrderTable {
 		return id;
 	}
 
-	public OrderTableGroup getOrderTableGroup() {
-		return orderTableGroup;
-	}
-
 	public Long getOrderTableGroupId() {
-		if (orderTableGroup != null) {
-			return orderTableGroup.getId();
-		}
-
-		return null;
+		return orderTableGroupId;
 	}
 
 	public NumberOfGuests getNumberOfGuests() {
@@ -70,7 +59,7 @@ public class OrderTable {
 	}
 
 	public boolean hasOrderTableGroup() {
-		return orderTableGroup != null;
+		return orderTableGroupId != null;
 	}
 
 	public void changeEmpty(boolean empty, OrderTableValidator validator) {
@@ -91,12 +80,12 @@ public class OrderTable {
 		this.numberOfGuests = numberOfGuests;
 	}
 
-	public void groupedBy(OrderTableGroup orderTableGroup) {
-		this.orderTableGroup = orderTableGroup;
+	public void groupedBy(Long orderTableGroupId) {
+		this.orderTableGroupId = orderTableGroupId;
 		this.empty = false;
 	}
 
 	public void ungrouped() {
-		this.orderTableGroup = null;
+		this.orderTableGroupId = null;
 	}
 }

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
@@ -24,7 +24,8 @@ public class OrderTable {
 	@JoinColumn(name = "table_group_id")
 	private OrderTableGroup orderTableGroup;
 
-	@OneToOne(mappedBy = "orderTable")
+	@OneToOne
+	@JoinColumn(name = "order_table_id")
 	private Order order;
 
 	@Embedded
@@ -33,6 +34,14 @@ public class OrderTable {
 	private boolean empty;
 
 	protected OrderTable() {
+	}
+
+	public static OrderTable of(Long id, NumberOfGuests numberOfGuests, boolean empty) {
+		OrderTable orderTable = new OrderTable();
+		orderTable.id = id;
+		orderTable.numberOfGuests = numberOfGuests;
+		orderTable.empty = empty;
+		return orderTable;
 	}
 
 	public static OrderTable of(NumberOfGuests numberOfGuests, boolean empty) {
@@ -96,10 +105,6 @@ public class OrderTable {
 		}
 
 		this.numberOfGuests = numberOfGuests;
-	}
-
-	public void setOrder(Order order) {
-		this.order = order;
 	}
 
 	public void groupedBy(OrderTableGroup orderTableGroup) {

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTable.java
@@ -7,10 +7,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
-import kitchenpos.order.domain.Order;
 import kitchenpos.ordertablegroup.domain.OrderTableGroup;
 
 @Table(name = "order_table")
@@ -23,10 +21,6 @@ public class OrderTable {
 	@ManyToOne
 	@JoinColumn(name = "table_group_id")
 	private OrderTableGroup orderTableGroup;
-
-	@OneToOne
-	@JoinColumn(name = "order_table_id")
-	private Order order;
 
 	@Embedded
 	private NumberOfGuests numberOfGuests;
@@ -59,10 +53,6 @@ public class OrderTable {
 		return orderTableGroup;
 	}
 
-	public Order getOrder() {
-		return order;
-	}
-
 	public Long getOrderTableGroupId() {
 		if (orderTableGroup != null) {
 			return orderTableGroup.getId();
@@ -83,20 +73,14 @@ public class OrderTable {
 		return orderTableGroup != null;
 	}
 
-	public void changeEmpty(boolean empty) {
+	public void changeEmpty(boolean empty, OrderTableValidator validator) {
 		if (hasOrderTableGroup()) {
 			throw new IllegalStateException("주문 테이블 그룹에 속해 있으면 빈 상태를 변경할 수 없습니다.");
 		}
 
-		if (hasNotCompletedOrder()) {
-			throw new IllegalStateException("완료되지 않은 주문이 남아 있는 경우 빈 상태를 변경할 수 없습니다.");
-		}
+		validator.validateNotCompletedOrderNotExist(id);
 
 		this.empty = empty;
-	}
-
-	public boolean hasNotCompletedOrder() {
-		return order != null && !order.isCompleted();
 	}
 
 	public void changeNumberOfGuests(NumberOfGuests numberOfGuests) {

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTableRepository.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTableRepository.java
@@ -11,4 +11,6 @@ public interface OrderTableRepository {
 	Optional<OrderTable> findById(Long id);
 
 	List<OrderTable> findAllByIdIn(List<Long> ids);
+
+	List<OrderTable> findByOrderTableGroupId(Long orderTableGroupId);
 }

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTableValidator.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTableValidator.java
@@ -1,0 +1,5 @@
+package kitchenpos.ordertable.domain;
+
+public interface OrderTableValidator {
+	void validateNotCompletedOrderNotExist(Long id);
+}

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTableValidatorImpl.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTableValidatorImpl.java
@@ -12,11 +12,11 @@ public class OrderTableValidatorImpl implements OrderTableValidator {
 
 	@Override
 	public void validateNotCompletedOrderNotExist(Long id) {
-		boolean hasNotCompletedOrder = orders.findByOrderTableId(id)
+		boolean isNotCompleted = orders.findByOrderTableId(id)
 			.stream()
 			.anyMatch(order -> !order.getOrderStatus().isCompletion());
 
-		if (hasNotCompletedOrder) {
+		if (isNotCompleted) {
 			throw new IllegalStateException("완료되지 않은 주문이 남아 있는 경우 빈 상태를 변경할 수 없습니다.");
 		}
 	}

--- a/src/main/java/kitchenpos/ordertable/domain/OrderTableValidatorImpl.java
+++ b/src/main/java/kitchenpos/ordertable/domain/OrderTableValidatorImpl.java
@@ -1,0 +1,23 @@
+package kitchenpos.ordertable.domain;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderTableValidatorImpl implements OrderTableValidator {
+	private final Orders orders;
+
+	public OrderTableValidatorImpl(Orders orders) {
+		this.orders = orders;
+	}
+
+	@Override
+	public void validateNotCompletedOrderNotExist(Long id) {
+		boolean hasNotCompletedOrder = orders.findByOrderTableId(id)
+			.stream()
+			.anyMatch(order -> !order.getOrderStatus().isCompletion());
+
+		if (hasNotCompletedOrder) {
+			throw new IllegalStateException("완료되지 않은 주문이 남아 있는 경우 빈 상태를 변경할 수 없습니다.");
+		}
+	}
+}

--- a/src/main/java/kitchenpos/ordertable/domain/Orders.java
+++ b/src/main/java/kitchenpos/ordertable/domain/Orders.java
@@ -1,0 +1,7 @@
+package kitchenpos.ordertable.domain;
+
+import java.util.List;
+
+public interface Orders {
+	List<Order> findByOrderTableId(Long orderTableId);
+}

--- a/src/main/java/kitchenpos/ordertable/dto/OrderTableDto.java
+++ b/src/main/java/kitchenpos/ordertable/dto/OrderTableDto.java
@@ -18,7 +18,7 @@ public class OrderTableDto {
 		this.empty = empty;
 	}
 
-	public static OrderTableDto of(OrderTable orderTable) {
+	public static OrderTableDto from(OrderTable orderTable) {
 		OrderTableDto dto = new OrderTableDto();
 		dto.id = orderTable.getId();
 		dto.tableGroupId = orderTable.getOrderTableGroupId();

--- a/src/main/java/kitchenpos/ordertable/dto/OrderTableRequest.java
+++ b/src/main/java/kitchenpos/ordertable/dto/OrderTableRequest.java
@@ -40,6 +40,6 @@ public class OrderTableRequest {
 	}
 
 	public OrderTable toOrderTable() {
-		return OrderTable.of(NumberOfGuests.of(numberOfGuests), empty);
+		return OrderTable.of(NumberOfGuests.from(numberOfGuests), empty);
 	}
 }

--- a/src/main/java/kitchenpos/ordertable/infra/OrdersImpl.java
+++ b/src/main/java/kitchenpos/ordertable/infra/OrdersImpl.java
@@ -1,0 +1,27 @@
+package kitchenpos.ordertable.infra;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.order.domain.Order;
+import kitchenpos.order.domain.OrderRepository;
+import kitchenpos.ordertable.domain.Orders;
+
+@Component
+public class OrdersImpl implements Orders {
+	private final OrderRepository orderRepository;
+
+	public OrdersImpl(OrderRepository orderRepository) {
+		this.orderRepository = orderRepository;
+	}
+
+	@Override
+	public List<kitchenpos.ordertable.domain.Order> findByOrderTableId(Long orderTableId) {
+		List<Order> orders = orderRepository.findByOrderTableId(orderTableId);
+		return orders.stream()
+			.map(order -> kitchenpos.ordertable.domain.Order.from(order.getOrderStatus().name()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/kitchenpos/ordertablegroup/application/OrderTableGroupService.java
+++ b/src/main/java/kitchenpos/ordertablegroup/application/OrderTableGroupService.java
@@ -29,8 +29,8 @@ public class OrderTableGroupService {
 	@Transactional
 	public OrderTableGroupDto create(OrderTableGroupCreateRequest request) {
 		List<OrderTable> orderTables = findOrderTablesBy(request.getOrderTableIds());
-		OrderTableGroup orderTableGroup = orderTableGroupRepository.save(OrderTableGroup.of(orderTables));
-		return OrderTableGroupDto.of(orderTableGroup);
+		OrderTableGroup orderTableGroup = orderTableGroupRepository.save(OrderTableGroup.from(orderTables));
+		return OrderTableGroupDto.from(orderTableGroup);
 	}
 
 	private List<OrderTable> findOrderTablesBy(List<Long> orderTableIds) {

--- a/src/main/java/kitchenpos/ordertablegroup/domain/Order.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/Order.java
@@ -1,0 +1,26 @@
+package kitchenpos.ordertablegroup.domain;
+
+public class Order {
+	private OrderStatus orderStatus;
+
+	private Order() {
+	}
+
+	public static Order from(String orderStatus) {
+		Order order = new Order();
+		order.orderStatus = OrderStatus.valueOf(orderStatus);
+		return order;
+	}
+
+	public OrderStatus getOrderStatus() {
+		return orderStatus;
+	}
+
+	public enum OrderStatus {
+		COOKING, MEAL, COMPLETION;
+
+		public boolean isCompletion() {
+			return this == COMPLETION;
+		}
+	}
+}

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTable.java
@@ -1,0 +1,34 @@
+package kitchenpos.ordertablegroup.domain;
+
+public class OrderTable {
+	private Long id;
+	private Long tableGroupId;
+	private boolean empty;
+
+	private OrderTable() {
+	}
+
+	public static OrderTable of(Long id, Long tableGroupId, boolean empty) {
+		OrderTable orderTable = new OrderTable();
+		orderTable.id = id;
+		orderTable.tableGroupId = tableGroupId;
+		orderTable.empty = empty;
+		return orderTable;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Long getTableGroupId() {
+		return tableGroupId;
+	}
+
+	public boolean isEmpty() {
+		return empty;
+	}
+
+	public boolean hasOrderTableGroup() {
+		return tableGroupId != null;
+	}
+}

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroup.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroup.java
@@ -37,7 +37,7 @@ public class OrderTableGroup {
 	protected OrderTableGroup() {
 	}
 
-	public static OrderTableGroup of(List<OrderTable> orderTables) {
+	public static OrderTableGroup from(List<OrderTable> orderTables) {
 		throwOnLessThanTwo(orderTables);
 		orderTables.forEach(OrderTableGroup::throwOnAlreadyHavingOrderTableGroup);
 		orderTables.forEach(OrderTableGroup::throwOnNotEmpty);

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroup.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroup.java
@@ -79,9 +79,10 @@ public class OrderTableGroup {
 	}
 
 	public void ungroup() {
-		if (orderTables.stream().anyMatch(OrderTable::hasNotCompletedOrder)) {
-			throw new IllegalStateException("주문 테이블에 완료되지 않은 주문이 있는 경우 주문 테이블 그룹을 해제할 수 없습니다.");
-		}
+		// TODO : fix this
+		// if (orderTables.stream().anyMatch(OrderTable::hasNotCompletedOrder)) {
+		// 	throw new IllegalStateException("주문 테이블에 완료되지 않은 주문이 있는 경우 주문 테이블 그룹을 해제할 수 없습니다.");
+		// }
 
 		orderTables.forEach(OrderTable::ungrouped);
 		orderTables = new ArrayList<>();

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroup.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroup.java
@@ -1,28 +1,24 @@
 package kitchenpos.ordertablegroup.domain;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.domain.AbstractAggregateRoot;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import kitchenpos.ordertable.domain.OrderTable;
 
 @Table(name = "table_group")
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-public class OrderTableGroup {
+public class OrderTableGroup extends AbstractAggregateRoot<OrderTableGroup> {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -31,39 +27,17 @@ public class OrderTableGroup {
 	@CreatedDate
 	private LocalDateTime createdDate;
 
-	@OneToMany(mappedBy = "orderTableGroup", cascade = CascadeType.MERGE)
-	private List<OrderTable> orderTables = new ArrayList<>();
-
 	protected OrderTableGroup() {
 	}
 
-	public static OrderTableGroup from(List<OrderTable> orderTables) {
-		throwOnLessThanTwo(orderTables);
-		orderTables.forEach(OrderTableGroup::throwOnAlreadyHavingOrderTableGroup);
-		orderTables.forEach(OrderTableGroup::throwOnNotEmpty);
+	public static OrderTableGroup newInstance() {
+		return new OrderTableGroup();
+	}
 
+	public static OrderTableGroup from(Long id) {
 		OrderTableGroup orderTableGroup = new OrderTableGroup();
-		orderTableGroup.orderTables = orderTables;
-		orderTableGroup.orderTables.forEach(orderTable -> orderTable.groupedBy(orderTableGroup));
+		orderTableGroup.id = id;
 		return orderTableGroup;
-	}
-
-	private static void throwOnLessThanTwo(List<OrderTable> orderTables) {
-		if (orderTables == null || orderTables.size() < 2) {
-			throw new IllegalArgumentException("주문 테이블이 2개 이상이어야 주문 테이블 그룹을 등록할 수 있습니다.");
-		}
-	}
-
-	private static void throwOnAlreadyHavingOrderTableGroup(OrderTable orderTable) {
-		if (orderTable.hasOrderTableGroup()) {
-			throw new IllegalArgumentException("이미 주문 테이블 그룹이 있는 경우 등록할 수 없습니다.");
-		}
-	}
-
-	private static void throwOnNotEmpty(OrderTable orderTable) {
-		if (!orderTable.isEmpty()) {
-			throw new IllegalArgumentException("주문 테이블이 비어있지 않은 경우 주문 테이블 그룹을 등록할 수 없습니다.");
-		}
 	}
 
 	public Long getId() {
@@ -74,17 +48,17 @@ public class OrderTableGroup {
 		return createdDate;
 	}
 
-	public List<OrderTable> getOrderTables() {
-		return orderTables;
+	public void group(List<Long> orderTableIds, OrderTableGroupValidator validator) {
+		validator.validateOrderTablesAreGreaterThanOrEqualToTwo(orderTableIds);
+		validator.validateNotGrouped(orderTableIds);
+		validator.validateOrderTableIsEmpty(orderTableIds);
+
+		registerEvent(new OrderTableGroupingEvent(id, orderTableIds));
 	}
 
-	public void ungroup() {
-		// TODO : fix this
-		// if (orderTables.stream().anyMatch(OrderTable::hasNotCompletedOrder)) {
-		// 	throw new IllegalStateException("주문 테이블에 완료되지 않은 주문이 있는 경우 주문 테이블 그룹을 해제할 수 없습니다.");
-		// }
+	public void ungroup(OrderTableGroupValidator validator) {
+		validator.validateNotCompletedOrderNotExist(id);
 
-		orderTables.forEach(OrderTable::ungrouped);
-		orderTables = new ArrayList<>();
+		registerEvent(new OrderTableUngroupingEvent(id));
 	}
 }

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroupValidator.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroupValidator.java
@@ -1,0 +1,13 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public interface OrderTableGroupValidator {
+	void validateOrderTablesAreGreaterThanOrEqualToTwo(List<Long> orderTableIds);
+
+	void validateNotGrouped(List<Long> orderTableIds);
+
+	void validateOrderTableIsEmpty(List<Long> orderTableIds);
+
+	void validateNotCompletedOrderNotExist(Long orderTableGroupId);
+}

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroupValidatorImpl.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroupValidatorImpl.java
@@ -1,0 +1,58 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderTableGroupValidatorImpl implements OrderTableGroupValidator {
+	private final OrderTables orderTables;
+	private final Orders orders;
+
+	public OrderTableGroupValidatorImpl(OrderTables orderTables, Orders orders) {
+		this.orderTables = orderTables;
+		this.orders = orders;
+	}
+
+	@Override
+	public void validateOrderTablesAreGreaterThanOrEqualToTwo(List<Long> orderTableIds) {
+		if (orderTables.findAllByIdIn(orderTableIds).size() < 2) {
+			throw new IllegalArgumentException("주문 테이블이 2개 이상이어야 주문 테이블 그룹을 등록할 수 있습니다.");
+		}
+	}
+
+	@Override
+	public void validateNotGrouped(List<Long> orderTableIds) {
+		boolean hasOrderTableGroup = orderTables.findAllByIdIn(orderTableIds)
+			.stream()
+			.anyMatch(OrderTable::hasOrderTableGroup);
+
+		if (hasOrderTableGroup) {
+			throw new IllegalArgumentException("이미 주문 테이블 그룹이 있는 경우 등록할 수 없습니다.");
+		}
+	}
+
+	@Override
+	public void validateOrderTableIsEmpty(List<Long> orderTableIds) {
+		boolean isNotEmpty = orderTables.findAllByIdIn(orderTableIds)
+			.stream()
+			.anyMatch(orderTable -> !orderTable.isEmpty());
+
+		if (isNotEmpty) {
+			throw new IllegalArgumentException("주문 테이블이 비어있지 않은 경우 주문 테이블 그룹을 등록할 수 없습니다.");
+		}
+	}
+
+	@Override
+	public void validateNotCompletedOrderNotExist(Long orderTableGroupId) {
+		boolean isNotCompleted = orderTables.findByOrderTableGroupId(orderTableGroupId)
+			.stream()
+			.map(orderTable -> orders.findByOrderTableId(orderTable.getId()))
+			.flatMap(List::stream)
+			.anyMatch(order -> !order.getOrderStatus().isCompletion());
+
+		if (isNotCompleted) {
+			throw new IllegalStateException("주문 테이블에 완료되지 않은 주문이 있는 경우 주문 테이블 그룹을 해제할 수 없습니다.");
+		}
+	}
+}

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroupingEvent.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableGroupingEvent.java
@@ -1,0 +1,21 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public class OrderTableGroupingEvent {
+	private final Long orderTableGroupId;
+	private final List<Long> orderTableIds;
+
+	public OrderTableGroupingEvent(Long orderTableGroupId, List<Long> orderTableIds) {
+		this.orderTableGroupId = orderTableGroupId;
+		this.orderTableIds = orderTableIds;
+	}
+
+	public Long getOrderTableGroupId() {
+		return orderTableGroupId;
+	}
+
+	public List<Long> getOrderTableIds() {
+		return orderTableIds;
+	}
+}

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableUngroupingEvent.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTableUngroupingEvent.java
@@ -1,0 +1,13 @@
+package kitchenpos.ordertablegroup.domain;
+
+public class OrderTableUngroupingEvent {
+	private final Long orderTableGroupId;
+
+	public OrderTableUngroupingEvent(Long orderTableGroupId) {
+		this.orderTableGroupId = orderTableGroupId;
+	}
+
+	public Long getOrderTableGroupId() {
+		return orderTableGroupId;
+	}
+}

--- a/src/main/java/kitchenpos/ordertablegroup/domain/OrderTables.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/OrderTables.java
@@ -1,0 +1,9 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public interface OrderTables {
+	List<OrderTable> findAllByIdIn(List<Long> ids);
+
+	List<OrderTable> findByOrderTableGroupId(Long orderTableGroupId);
+}

--- a/src/main/java/kitchenpos/ordertablegroup/domain/Orders.java
+++ b/src/main/java/kitchenpos/ordertablegroup/domain/Orders.java
@@ -1,0 +1,7 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public interface Orders {
+	List<Order> findByOrderTableId(Long orderTableId);
+}

--- a/src/main/java/kitchenpos/ordertablegroup/dto/OrderTableGroupDto.java
+++ b/src/main/java/kitchenpos/ordertablegroup/dto/OrderTableGroupDto.java
@@ -22,13 +22,13 @@ public class OrderTableGroupDto {
 		this.orderTables = orderTables;
 	}
 
-	public static OrderTableGroupDto of(OrderTableGroup orderTableGroup) {
+	public static OrderTableGroupDto from(OrderTableGroup orderTableGroup) {
 		OrderTableGroupDto dto = new OrderTableGroupDto();
 		dto.id = orderTableGroup.getId();
 		dto.createdDate = orderTableGroup.getCreatedDate();
 		dto.orderTables = orderTableGroup.getOrderTables()
 			.stream()
-			.map(OrderTableDto::of)
+			.map(OrderTableDto::from)
 			.collect(Collectors.toList());
 		return dto;
 	}

--- a/src/main/java/kitchenpos/ordertablegroup/dto/OrderTableGroupDto.java
+++ b/src/main/java/kitchenpos/ordertablegroup/dto/OrderTableGroupDto.java
@@ -1,35 +1,25 @@
 package kitchenpos.ordertablegroup.dto;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
-import kitchenpos.ordertable.dto.OrderTableDto;
 import kitchenpos.ordertablegroup.domain.OrderTableGroup;
 
 public class OrderTableGroupDto {
 	private Long id;
 	private LocalDateTime createdDate;
-	private List<OrderTableDto> orderTables;
 
 	public OrderTableGroupDto() {
 	}
 
-	public OrderTableGroupDto(Long id, LocalDateTime createdDate,
-		List<OrderTableDto> orderTables) {
+	public OrderTableGroupDto(Long id, LocalDateTime createdDate) {
 		this.id = id;
 		this.createdDate = createdDate;
-		this.orderTables = orderTables;
 	}
 
 	public static OrderTableGroupDto from(OrderTableGroup orderTableGroup) {
 		OrderTableGroupDto dto = new OrderTableGroupDto();
 		dto.id = orderTableGroup.getId();
 		dto.createdDate = orderTableGroup.getCreatedDate();
-		dto.orderTables = orderTableGroup.getOrderTables()
-			.stream()
-			.map(OrderTableDto::from)
-			.collect(Collectors.toList());
 		return dto;
 	}
 
@@ -39,9 +29,5 @@ public class OrderTableGroupDto {
 
 	public LocalDateTime getCreatedDate() {
 		return createdDate;
-	}
-
-	public List<OrderTableDto> getOrderTables() {
-		return orderTables;
 	}
 }

--- a/src/main/java/kitchenpos/ordertablegroup/infra/OrderTablesImpl.java
+++ b/src/main/java/kitchenpos/ordertablegroup/infra/OrderTablesImpl.java
@@ -1,0 +1,41 @@
+package kitchenpos.ordertablegroup.infra;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.ordertable.domain.OrderTable;
+import kitchenpos.ordertable.domain.OrderTableRepository;
+import kitchenpos.ordertablegroup.domain.OrderTables;
+
+@Component(value = "OrderTableGroupOrderTables")
+public class OrderTablesImpl implements OrderTables {
+	private final OrderTableRepository orderTableRepository;
+
+	public OrderTablesImpl(OrderTableRepository orderTableRepository) {
+		this.orderTableRepository = orderTableRepository;
+	}
+
+	@Override
+	public List<kitchenpos.ordertablegroup.domain.OrderTable> findAllByIdIn(List<Long> ids) {
+		List<OrderTable> orderTables = orderTableRepository.findAllByIdIn(ids);
+		return orderTables.stream()
+			.map(orderTable -> kitchenpos.ordertablegroup.domain.OrderTable.of(
+				orderTable.getId(),
+				orderTable.getOrderTableGroupId(),
+				orderTable.isEmpty()))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public List<kitchenpos.ordertablegroup.domain.OrderTable> findByOrderTableGroupId(Long orderTableGroupId) {
+		List<OrderTable> orderTables = orderTableRepository.findByOrderTableGroupId(orderTableGroupId);
+		return orderTables.stream()
+			.map(orderTable -> kitchenpos.ordertablegroup.domain.OrderTable.of(
+				orderTable.getId(),
+				orderTable.getOrderTableGroupId(),
+				orderTable.isEmpty()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/kitchenpos/ordertablegroup/infra/OrdersImpl.java
+++ b/src/main/java/kitchenpos/ordertablegroup/infra/OrdersImpl.java
@@ -1,0 +1,27 @@
+package kitchenpos.ordertablegroup.infra;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import kitchenpos.order.domain.Order;
+import kitchenpos.order.domain.OrderRepository;
+import kitchenpos.ordertablegroup.domain.Orders;
+
+@Component(value = "OrderTableGroupOrders")
+public class OrdersImpl implements Orders {
+	private final OrderRepository orderRepository;
+
+	public OrdersImpl(OrderRepository orderRepository) {
+		this.orderRepository = orderRepository;
+	}
+
+	@Override
+	public List<kitchenpos.ordertablegroup.domain.Order> findByOrderTableId(Long orderTableId) {
+		List<Order> orders = orderRepository.findByOrderTableId(orderTableId);
+		return orders.stream()
+			.map(order -> kitchenpos.ordertablegroup.domain.Order.from(order.getOrderStatus().name()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/kitchenpos/product/application/ProductService.java
+++ b/src/main/java/kitchenpos/product/application/ProductService.java
@@ -23,13 +23,13 @@ public class ProductService {
 	@Transactional
 	public ProductDto create(ProductCreateRequest request) {
 		Product product = productRepository.save(request.toProduct());
-		return ProductDto.of(product);
+		return ProductDto.from(product);
 	}
 
 	public List<ProductDto> list() {
 		List<Product> products = productRepository.findAll();
 		return products.stream()
-			.map(ProductDto::of)
+			.map(ProductDto::from)
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/kitchenpos/product/domain/Product.java
+++ b/src/main/java/kitchenpos/product/domain/Product.java
@@ -26,6 +26,14 @@ public class Product {
 	protected Product() {
 	}
 
+	public static Product of(Long id, Name name, Price price) {
+		Product product = new Product();
+		product.id = id;
+		product.name = name;
+		product.price = price;
+		return product;
+	}
+
 	public static Product of(Name name, Price price) {
 		Product product = new Product();
 		product.name = name;

--- a/src/main/java/kitchenpos/product/domain/ProductRepository.java
+++ b/src/main/java/kitchenpos/product/domain/ProductRepository.java
@@ -9,4 +9,6 @@ public interface ProductRepository {
 	List<Product> findAll();
 
 	Optional<Product> findById(Long id);
+
+	List<Product> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/kitchenpos/product/dto/ProductCreateRequest.java
+++ b/src/main/java/kitchenpos/product/dto/ProductCreateRequest.java
@@ -35,6 +35,6 @@ public class ProductCreateRequest {
 	}
 
 	public Product toProduct() {
-		return Product.of(Name.of(name), Price.of(price));
+		return Product.of(Name.from(name), Price.from(price));
 	}
 }

--- a/src/main/java/kitchenpos/product/dto/ProductDto.java
+++ b/src/main/java/kitchenpos/product/dto/ProductDto.java
@@ -18,7 +18,7 @@ public class ProductDto {
 		this.price = price;
 	}
 
-	public static ProductDto of(Product product) {
+	public static ProductDto from(Product product) {
 		ProductDto dto = new ProductDto();
 		dto.id = product.getId();
 		dto.name = product.getName().getValue();

--- a/src/test/java/kitchenpos/common/domain/NameTest.java
+++ b/src/test/java/kitchenpos/common/domain/NameTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 class NameTest {
 	@DisplayName("생성")
 	@Test
-	void of() {
+	void from() {
 		// given
 		String value = "이름";
 
 		// when
-		Name name = Name.of(value);
+		Name name = Name.from(value);
 
 		// then
 		assertThat(name.getValue()).isEqualTo(value);
@@ -26,11 +26,11 @@ class NameTest {
 	@DisplayName("생성 실패 - 이름이 없거나 빈 값인 경우")
 	@ParameterizedTest
 	@NullAndEmptySource
-	void ofFailOnNullOrEmptyName(String value) {
+	void fromFailOnNullOrEmptyName(String value) {
 		// given
 
 		// when
-		ThrowingCallable throwingCallable = () -> Name.of(value);
+		ThrowingCallable throwingCallable = () -> Name.from(value);
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -43,8 +43,8 @@ class NameTest {
 		String name = "이름";
 
 		// when
-		Name actual = Name.of(name);
-		Name expected = Name.of(name);
+		Name actual = Name.from(name);
+		Name expected = Name.from(name);
 
 		// then
 		assertThat(actual).isEqualTo(expected);

--- a/src/test/java/kitchenpos/common/domain/PriceTest.java
+++ b/src/test/java/kitchenpos/common/domain/PriceTest.java
@@ -11,18 +11,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import kitchenpos.common.domain.Price;
-
 @DisplayName("가격")
 class PriceTest {
 	@DisplayName("생성")
 	@ParameterizedTest
 	@ValueSource(strings = {"0", "17000"})
-	void of(BigDecimal value) {
+	void from(BigDecimal value) {
 		// given
 
 		// when
-		Price price = Price.of(value);
+		Price price = Price.from(value);
 
 		// then
 		assertThat(price.getValue()).isEqualTo(value);
@@ -32,11 +30,11 @@ class PriceTest {
 	@ParameterizedTest
 	@NullSource
 	@ValueSource(strings = {"-10000"})
-	void ofFailOnNullOrNegativePrice(BigDecimal value) {
+	void fromFailOnNullOrNegativePrice(BigDecimal value) {
 		// given
 
 		// when
-		ThrowingCallable throwingCallable = () -> Price.of(value);
+		ThrowingCallable throwingCallable = () -> Price.from(value);
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -49,8 +47,8 @@ class PriceTest {
 		BigDecimal value = BigDecimal.valueOf(10000);
 
 		// when
-		Price aPrice = Price.of(value);
-		Price bPrice = Price.of(value);
+		Price aPrice = Price.from(value);
+		Price bPrice = Price.from(value);
 
 		// then
 		assertThat(aPrice).isEqualTo(bPrice);

--- a/src/test/java/kitchenpos/common/domain/PriceTest.java
+++ b/src/test/java/kitchenpos/common/domain/PriceTest.java
@@ -53,4 +53,18 @@ class PriceTest {
 		// then
 		assertThat(aPrice).isEqualTo(bPrice);
 	}
+
+	@DisplayName("더하기")
+	@Test
+	void add() {
+		// given
+		Price augend = Price.from(BigDecimal.valueOf(10000));
+		Price addend = Price.from(BigDecimal.valueOf(20000));
+
+		// when
+		Price sum = augend.add(addend);
+
+		// then
+		assertThat(sum).isEqualTo(Price.from(BigDecimal.valueOf(30000)));
+	}
 }

--- a/src/test/java/kitchenpos/common/domain/PriceTest.java
+++ b/src/test/java/kitchenpos/common/domain/PriceTest.java
@@ -67,4 +67,18 @@ class PriceTest {
 		// then
 		assertThat(sum).isEqualTo(Price.from(BigDecimal.valueOf(30000)));
 	}
+
+	@DisplayName("곱하기")
+	@Test
+	void multiply() {
+		// given
+		Price multiplicand = Price.from(BigDecimal.valueOf(10000));
+		Quantity multiplier = Quantity.from(2L);
+
+		// when
+		Price product = multiplicand.multiply(multiplier);
+
+		// then
+		assertThat(product).isEqualTo(Price.from(BigDecimal.valueOf(20000)));
+	}
 }

--- a/src/test/java/kitchenpos/common/domain/QuantityTest.java
+++ b/src/test/java/kitchenpos/common/domain/QuantityTest.java
@@ -16,13 +16,13 @@ class QuantityTest {
 	@Test
 	void from() {
 		// given
-		long quantity = 2;
+		long value = 2;
 
 		// when
-		Quantity menuProductQuantity = Quantity.from(quantity);
+		Quantity quantity = Quantity.from(value);
 
 		// then
-		assertThat(menuProductQuantity.getValue()).isEqualTo(quantity);
+		assertThat(quantity.getValue()).isEqualTo(value);
 	}
 
 	@DisplayName("생성 실패 - 수량이 없거나 음수인 경우")

--- a/src/test/java/kitchenpos/common/domain/QuantityTest.java
+++ b/src/test/java/kitchenpos/common/domain/QuantityTest.java
@@ -9,19 +9,17 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import kitchenpos.common.domain.Quantity;
-
 @DisplayName("수량")
 class QuantityTest {
 
 	@DisplayName("생성")
 	@Test
-	void of() {
+	void from() {
 		// given
 		long quantity = 2;
 
 		// when
-		Quantity menuProductQuantity = Quantity.of(quantity);
+		Quantity menuProductQuantity = Quantity.from(quantity);
 
 		// then
 		assertThat(menuProductQuantity.getValue()).isEqualTo(quantity);
@@ -31,11 +29,11 @@ class QuantityTest {
 	@ParameterizedTest
 	@NullSource
 	@ValueSource(strings = {"-1"})
-	void ofFailOnNullOrNegativeQuantity(Long quantity) {
+	void fromFailOnNullOrNegativeQuantity(Long quantity) {
 		// given
 
 		// when
-		ThrowingCallable throwingCallable = () -> Quantity.of(quantity);
+		ThrowingCallable throwingCallable = () -> Quantity.from(quantity);
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -48,8 +46,8 @@ class QuantityTest {
 		long quantity = 2;
 
 		// when
-		Quantity actual = Quantity.of(quantity);
-		Quantity expected = Quantity.of(quantity);
+		Quantity actual = Quantity.from(quantity);
+		Quantity expected = Quantity.from(quantity);
 
 		// then
 		assertThat(actual).isEqualTo(expected);

--- a/src/test/java/kitchenpos/menu/MenuFixture.java
+++ b/src/test/java/kitchenpos/menu/MenuFixture.java
@@ -1,12 +1,29 @@
 package kitchenpos.menu;
 
+import static kitchenpos.menu.MenuProductFixture.*;
+import static kitchenpos.menugroup.MenuGroupFixture.*;
+
 import java.math.BigDecimal;
 import java.util.Collections;
 
+import kitchenpos.common.domain.Name;
+import kitchenpos.common.domain.Price;
+import kitchenpos.menu.domain.ValidMenuValidator;
+import kitchenpos.menu.domain.Menu;
 import kitchenpos.menu.dto.MenuCreateRequest;
 import kitchenpos.menu.dto.MenuProductDto;
 
 public class MenuFixture {
+	public static Menu 후라이드후라이드_메뉴() {
+		return Menu.of(
+			1L,
+			Name.from("후라이드+후라이드"),
+			Price.from(BigDecimal.valueOf(19000)),
+			추천_메뉴_그룹().getId(),
+			Collections.singletonList(MenuProductDto.from(후라이드치킨_2개_메뉴_상품())),
+			new ValidMenuValidator());
+	}
+
 	public static MenuCreateRequest 후라이드후라이드_메뉴_요청(Long menuGroupId, Long productId) {
 		return new MenuCreateRequest(
 			"후라이드+후라이드",

--- a/src/test/java/kitchenpos/menu/MenuProductFixture.java
+++ b/src/test/java/kitchenpos/menu/MenuProductFixture.java
@@ -1,0 +1,20 @@
+package kitchenpos.menu;
+
+import static kitchenpos.product.ProductFixture.*;
+
+import kitchenpos.common.domain.Quantity;
+import kitchenpos.menu.domain.MenuProduct;
+
+public class MenuProductFixture {
+	public static MenuProduct 후라이드치킨_2개_메뉴_상품() {
+		return MenuProduct.of(1L, 후라이드치킨_상품().getId(), Quantity.from(2L));
+	}
+
+	public static MenuProduct 강정치킨_메뉴_상품() {
+		return MenuProduct.of(2L, 강정치킨_상품().getId(), Quantity.from(1L));
+	}
+
+	public static MenuProduct 양념치킨_메뉴_상품() {
+		return MenuProduct.of(3L, 양념치킨_상품().getId(), Quantity.from(1L));
+	}
+}

--- a/src/test/java/kitchenpos/menu/domain/MenuProductTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuProductTest.java
@@ -19,8 +19,8 @@ public class MenuProductTest {
 	@Test
 	void of() {
 		// given
-		Product product = Product.of(Name.of("강정치킨"), Price.of(BigDecimal.valueOf(17000)));
-		Quantity quantity = Quantity.of(2L);
+		Product product = Product.of(Name.from("강정치킨"), Price.from(BigDecimal.valueOf(17000)));
+		Quantity quantity = Quantity.from(2L);
 
 		// when
 		MenuProduct menuProduct = MenuProduct.of(product, quantity);

--- a/src/test/java/kitchenpos/menu/domain/MenuProductTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuProductTest.java
@@ -1,14 +1,11 @@
 package kitchenpos.menu.domain;
 
+import static kitchenpos.product.ProductFixture.*;
 import static org.assertj.core.api.Assertions.*;
-
-import java.math.BigDecimal;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Name;
-import kitchenpos.common.domain.Price;
 import kitchenpos.common.domain.Quantity;
 import kitchenpos.product.domain.Product;
 
@@ -19,31 +16,14 @@ public class MenuProductTest {
 	@Test
 	void of() {
 		// given
-		Product product = Product.of(Name.from("강정치킨"), Price.from(BigDecimal.valueOf(17000)));
-		Quantity quantity = Quantity.from(2L);
+		Product product = 강정치킨_상품();
+		Quantity quantity = Quantity.from(1L);
 
 		// when
-		MenuProduct menuProduct = MenuProduct.of(product, quantity);
+		MenuProduct menuProduct = MenuProduct.of(product.getId(), quantity);
 
 		// then
-		assertThat(menuProduct.getProduct()).isEqualTo(product);
+		assertThat(menuProduct.getProductId()).isEqualTo(product.getId());
 		assertThat(menuProduct.getQuantity()).isEqualTo(quantity);
-	}
-
-	@DisplayName("총 금액을 구할 수 있다.")
-	@Test
-	void getTotalPrice() {
-		// given
-		MenuProduct menuProduct = MenuProduct.of(
-			Product.of(
-				Name.from("강정치킨"),
-				Price.from(BigDecimal.valueOf(17000))),
-			Quantity.from(2L));
-
-		// when
-		Price price = menuProduct.getTotalPrice();
-
-		// then
-		assertThat(price).isEqualTo(Price.from(BigDecimal.valueOf(34000)));
 	}
 }

--- a/src/test/java/kitchenpos/menu/domain/MenuProductTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuProductTest.java
@@ -29,4 +29,21 @@ public class MenuProductTest {
 		assertThat(menuProduct.getProduct()).isEqualTo(product);
 		assertThat(menuProduct.getQuantity()).isEqualTo(quantity);
 	}
+
+	@DisplayName("총 금액을 구할 수 있다.")
+	@Test
+	void getTotalPrice() {
+		// given
+		MenuProduct menuProduct = MenuProduct.of(
+			Product.of(
+				Name.from("강정치킨"),
+				Price.from(BigDecimal.valueOf(17000))),
+			Quantity.from(2L));
+
+		// when
+		Price price = menuProduct.getTotalPrice();
+
+		// then
+		assertThat(price).isEqualTo(Price.from(BigDecimal.valueOf(34000)));
+	}
 }

--- a/src/test/java/kitchenpos/menu/domain/MenuProductsTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuProductsTest.java
@@ -1,8 +1,8 @@
 package kitchenpos.menu.domain;
 
+import static kitchenpos.menu.MenuProductFixture.*;
 import static org.assertj.core.api.Assertions.*;
 
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -11,11 +11,6 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Name;
-import kitchenpos.common.domain.Price;
-import kitchenpos.common.domain.Quantity;
-import kitchenpos.product.domain.Product;
-
 @DisplayName("메뉴 상품들")
 class MenuProductsTest {
 
@@ -23,16 +18,8 @@ class MenuProductsTest {
 	@Test
 	void from() {
 		// given
-		MenuProduct menuProduct1 = MenuProduct.of(
-			Product.of(
-				Name.from("강정치킨"),
-				Price.from(BigDecimal.valueOf(17000))),
-			Quantity.from(1L));
-		MenuProduct menuProduct2 = MenuProduct.of(
-			Product.of(
-				Name.from("양념치킨"),
-				Price.from(BigDecimal.valueOf(18000))),
-			Quantity.from(2L));
+		MenuProduct menuProduct1 = 강정치킨_메뉴_상품();
+		MenuProduct menuProduct2 = 양념치킨_메뉴_상품();
 
 		// when
 		MenuProducts.from(Arrays.asList(menuProduct1, menuProduct2));
@@ -49,28 +36,5 @@ class MenuProductsTest {
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
-	}
-
-	@DisplayName("총 금액을 구할 수 있다.")
-	@Test
-	void getTotalPrice() {
-		// given
-		MenuProducts menuProducts = MenuProducts.from(Arrays.asList(
-			MenuProduct.of(
-				Product.of(
-					Name.from("강정치킨"),
-					Price.from(BigDecimal.valueOf(17000))),
-				Quantity.from(1L)),
-			MenuProduct.of(
-				Product.of(
-					Name.from("양념치킨"),
-					Price.from(BigDecimal.valueOf(18000))),
-				Quantity.from(2L))));
-
-		// when
-		Price actual = menuProducts.getTotalPrice();
-
-		// then
-		assertThat(actual).isEqualTo(Price.from(BigDecimal.valueOf(53000)));
 	}
 }

--- a/src/test/java/kitchenpos/menu/domain/MenuProductsTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuProductsTest.java
@@ -21,31 +21,31 @@ class MenuProductsTest {
 
 	@DisplayName("생성")
 	@Test
-	void of() {
+	void from() {
 		// given
 		MenuProduct menuProduct1 = MenuProduct.of(
 			Product.of(
-				Name.of("강정치킨"),
-				Price.of(BigDecimal.valueOf(17000))),
-			Quantity.of(1L));
+				Name.from("강정치킨"),
+				Price.from(BigDecimal.valueOf(17000))),
+			Quantity.from(1L));
 		MenuProduct menuProduct2 = MenuProduct.of(
 			Product.of(
-				Name.of("양념치킨"),
-				Price.of(BigDecimal.valueOf(18000))),
-			Quantity.of(2L));
+				Name.from("양념치킨"),
+				Price.from(BigDecimal.valueOf(18000))),
+			Quantity.from(2L));
 
 		// when
-		MenuProducts.of(Arrays.asList(menuProduct1, menuProduct2));
+		MenuProducts.from(Arrays.asList(menuProduct1, menuProduct2));
 	}
 
 	@DisplayName("생성 실패 - 한개 이상이어야 한다.")
 	@Test
-	void ofFailOnEmpty() {
+	void fromFailOnEmpty() {
 		// given
 		List<MenuProduct> empty = Collections.emptyList();
 
 		// when
-		ThrowingCallable throwingCallable = () -> MenuProducts.of(empty);
+		ThrowingCallable throwingCallable = () -> MenuProducts.from(empty);
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -55,22 +55,22 @@ class MenuProductsTest {
 	@Test
 	void getTotalPrice() {
 		// given
-		MenuProducts menuProducts = MenuProducts.of(Arrays.asList(
+		MenuProducts menuProducts = MenuProducts.from(Arrays.asList(
 			MenuProduct.of(
 				Product.of(
-					Name.of("강정치킨"),
-					Price.of(BigDecimal.valueOf(17000))),
-				Quantity.of(1L)),
+					Name.from("강정치킨"),
+					Price.from(BigDecimal.valueOf(17000))),
+				Quantity.from(1L)),
 			MenuProduct.of(
 				Product.of(
-					Name.of("양념치킨"),
-					Price.of(BigDecimal.valueOf(18000))),
-				Quantity.of(2L))));
+					Name.from("양념치킨"),
+					Price.from(BigDecimal.valueOf(18000))),
+				Quantity.from(2L))));
 
 		// when
 		Price actual = menuProducts.getTotalPrice();
 
 		// then
-		assertThat(actual).isEqualTo(Price.of(BigDecimal.valueOf(53000)));
+		assertThat(actual).isEqualTo(Price.from(BigDecimal.valueOf(53000)));
 	}
 }

--- a/src/test/java/kitchenpos/menu/domain/MenuTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.menu.domain;
 
+import static kitchenpos.menugroup.MenuGroupFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,7 +26,7 @@ class MenuTest {
 		// given
 		Name name = Name.from("후라이드+후라이드");
 		Price price = Price.from(BigDecimal.valueOf(25000));
-		MenuGroup menuGroup = MenuGroup.from(Name.from("추천메뉴"));
+		MenuGroup menuGroup = 추천_메뉴_그룹();
 		MenuProducts menuProducts = MenuProducts.from(Collections.singletonList(
 			MenuProduct.of(
 				Product.of(
@@ -34,14 +35,14 @@ class MenuTest {
 				Quantity.from(2L))));
 
 		// when
-		Menu menu = Menu.of(name, price, menuGroup, menuProducts);
+		Menu menu = Menu.of(name, price, menuGroup.getId(), menuProducts);
 
 		// then
 		assertAll(
 			() -> assertThat(menu).isNotNull(),
 			() -> assertThat(menu.getName()).isEqualTo(name),
 			() -> assertThat(menu.getPrice()).isEqualTo(price),
-			() -> assertThat(menu.getMenuGroup()).isEqualTo(menuGroup),
+			() -> assertThat(menu.getMenuGroupId()).isEqualTo(menuGroup.getId()),
 			() -> assertThat(menu.getMenuProducts()).isEqualTo(menuProducts)
 		);
 	}
@@ -52,7 +53,7 @@ class MenuTest {
 		// given
 		Name name = Name.from("후라이드+후라이드");
 		Price price = Price.from(BigDecimal.valueOf(100000));
-		MenuGroup menuGroup = MenuGroup.from(Name.from("추천메뉴"));
+		MenuGroup menuGroup = 추천_메뉴_그룹();
 		MenuProducts menuProducts = MenuProducts.from(Collections.singletonList(
 			MenuProduct.of(
 				Product.of(
@@ -61,7 +62,7 @@ class MenuTest {
 				Quantity.from(2L))));
 
 		// when
-		ThrowingCallable throwingCallable = () -> Menu.of(name, price, menuGroup, menuProducts);
+		ThrowingCallable throwingCallable = () -> Menu.of(name, price, menuGroup.getId(), menuProducts);
 
 		// when & then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/kitchenpos/menu/domain/MenuTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.menu.domain;
 
+import static kitchenpos.menu.MenuProductFixture.*;
 import static kitchenpos.menugroup.MenuGroupFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
@@ -13,9 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import kitchenpos.common.domain.Name;
 import kitchenpos.common.domain.Price;
-import kitchenpos.common.domain.Quantity;
+import kitchenpos.menu.dto.MenuProductDto;
 import kitchenpos.menugroup.domain.MenuGroup;
-import kitchenpos.product.domain.Product;
 
 @DisplayName("메뉴")
 class MenuTest {
@@ -27,15 +27,16 @@ class MenuTest {
 		Name name = Name.from("후라이드+후라이드");
 		Price price = Price.from(BigDecimal.valueOf(25000));
 		MenuGroup menuGroup = 추천_메뉴_그룹();
-		MenuProducts menuProducts = MenuProducts.from(Collections.singletonList(
-			MenuProduct.of(
-				Product.of(
-					Name.from("후라이드치킨"),
-					Price.from(BigDecimal.valueOf(17000))),
-				Quantity.from(2L))));
+		MenuProduct menuProduct = 후라이드치킨_2개_메뉴_상품();
+		MenuValidator menuValidator = new ValidMenuValidator();
 
 		// when
-		Menu menu = Menu.of(name, price, menuGroup.getId(), menuProducts);
+		Menu menu = Menu.of(
+			name,
+			price,
+			menuGroup.getId(),
+			Collections.singletonList(MenuProductDto.from(menuProduct)),
+			menuValidator);
 
 		// then
 		assertAll(
@@ -43,8 +44,7 @@ class MenuTest {
 			() -> assertThat(menu.getName()).isEqualTo(name),
 			() -> assertThat(menu.getPrice()).isEqualTo(price),
 			() -> assertThat(menu.getMenuGroupId()).isEqualTo(menuGroup.getId()),
-			() -> assertThat(menu.getMenuProducts()).isEqualTo(menuProducts)
-		);
+			() -> assertThat(menu.getMenuProducts().size()).isEqualTo(1));
 	}
 
 	@DisplayName("생성 실패 - 메뉴의 가격이 메뉴 상품들의 전체 가격보다 큰 경우")
@@ -54,15 +54,16 @@ class MenuTest {
 		Name name = Name.from("후라이드+후라이드");
 		Price price = Price.from(BigDecimal.valueOf(100000));
 		MenuGroup menuGroup = 추천_메뉴_그룹();
-		MenuProducts menuProducts = MenuProducts.from(Collections.singletonList(
-			MenuProduct.of(
-				Product.of(
-					Name.from("후라이드치킨"),
-					Price.from(BigDecimal.valueOf(17000))),
-				Quantity.from(2L))));
+		MenuProduct menuProduct = 후라이드치킨_2개_메뉴_상품();
+		MenuValidator menuValidator = new PriceInvalidMenuValidator();
 
 		// when
-		ThrowingCallable throwingCallable = () -> Menu.of(name, price, menuGroup.getId(), menuProducts);
+		ThrowingCallable throwingCallable = () -> Menu.of(
+			name,
+			price,
+			menuGroup.getId(),
+			Collections.singletonList(MenuProductDto.from(menuProduct)),
+			menuValidator);
 
 		// when & then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/kitchenpos/menu/domain/MenuTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuTest.java
@@ -23,15 +23,15 @@ class MenuTest {
 	@Test
 	void of() {
 		// given
-		Name name = Name.of("후라이드+후라이드");
-		Price price = Price.of(BigDecimal.valueOf(25000));
-		MenuGroup menuGroup = MenuGroup.of(Name.of("추천메뉴"));
-		MenuProducts menuProducts = MenuProducts.of(Collections.singletonList(
+		Name name = Name.from("후라이드+후라이드");
+		Price price = Price.from(BigDecimal.valueOf(25000));
+		MenuGroup menuGroup = MenuGroup.from(Name.from("추천메뉴"));
+		MenuProducts menuProducts = MenuProducts.from(Collections.singletonList(
 			MenuProduct.of(
 				Product.of(
-					Name.of("후라이드치킨"),
-					Price.of(BigDecimal.valueOf(17000))),
-				Quantity.of(2L))));
+					Name.from("후라이드치킨"),
+					Price.from(BigDecimal.valueOf(17000))),
+				Quantity.from(2L))));
 
 		// when
 		Menu menu = Menu.of(name, price, menuGroup, menuProducts);
@@ -50,15 +50,15 @@ class MenuTest {
 	@Test
 	void ofFailOnPriceInvalid() {
 		// given
-		Name name = Name.of("후라이드+후라이드");
-		Price price = Price.of(BigDecimal.valueOf(100000));
-		MenuGroup menuGroup = MenuGroup.of(Name.of("추천메뉴"));
-		MenuProducts menuProducts = MenuProducts.of(Collections.singletonList(
+		Name name = Name.from("후라이드+후라이드");
+		Price price = Price.from(BigDecimal.valueOf(100000));
+		MenuGroup menuGroup = MenuGroup.from(Name.from("추천메뉴"));
+		MenuProducts menuProducts = MenuProducts.from(Collections.singletonList(
 			MenuProduct.of(
 				Product.of(
-					Name.of("후라이드치킨"),
-					Price.of(BigDecimal.valueOf(17000))),
-				Quantity.of(2L))));
+					Name.from("후라이드치킨"),
+					Price.from(BigDecimal.valueOf(17000))),
+				Quantity.from(2L))));
 
 		// when
 		ThrowingCallable throwingCallable = () -> Menu.of(name, price, menuGroup, menuProducts);

--- a/src/test/java/kitchenpos/menu/domain/MenuValidatorTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuValidatorTest.java
@@ -22,6 +22,7 @@ import kitchenpos.menugroup.infra.repository.InMemoryMenuGroupRepository;
 import kitchenpos.product.domain.ProductRepository;
 import kitchenpos.product.infra.repository.InMemoryProductRepository;
 
+@DisplayName("메뉴 검증자")
 class MenuValidatorTest {
 	private MenuGroupRepository menuGroupRepository;
 	private ProductRepository productRepository;

--- a/src/test/java/kitchenpos/menu/domain/MenuValidatorTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuValidatorTest.java
@@ -1,0 +1,116 @@
+package kitchenpos.menu.domain;
+
+import static kitchenpos.menu.MenuProductFixture.*;
+import static kitchenpos.menugroup.MenuGroupFixture.*;
+import static kitchenpos.product.ProductFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.ThrowableAssert.*;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kitchenpos.common.domain.Price;
+import kitchenpos.menu.dto.MenuProductDto;
+import kitchenpos.menu.infra.MenuGroupsImpl;
+import kitchenpos.menu.infra.ProductsImpl;
+import kitchenpos.menugroup.domain.MenuGroupRepository;
+import kitchenpos.menugroup.infra.repository.InMemoryMenuGroupRepository;
+import kitchenpos.product.domain.ProductRepository;
+import kitchenpos.product.infra.repository.InMemoryProductRepository;
+
+class MenuValidatorTest {
+	private MenuGroupRepository menuGroupRepository;
+	private ProductRepository productRepository;
+	private MenuValidator menuValidator;
+
+	@BeforeEach
+	void setUp() {
+		menuGroupRepository = new InMemoryMenuGroupRepository();
+		productRepository = new InMemoryProductRepository();
+		menuValidator = new MenuValidatorImpl(
+			new MenuGroupsImpl(menuGroupRepository),
+			new ProductsImpl(productRepository));
+	}
+
+	@DisplayName("메뉴 그룹이 존재하는지 검증한다.")
+	@Test
+	void validateMenuGroupExist() {
+		// given
+		menuGroupRepository.save(추천_메뉴_그룹());
+
+		// when
+		menuValidator.validateMenuGroupExist(추천_메뉴_그룹().getId());
+
+		// then
+	}
+
+	@DisplayName("메뉴 그룹이 존재하는지 검증한다. (실패)")
+	@Test
+	void validateMenuGroupExistFail() {
+		// given
+
+		// when
+		ThrowingCallable throwingCallable = () -> menuValidator.validateMenuGroupExist(추천_메뉴_그룹().getId());
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("상품이 존재하는지 검증한다.")
+	@Test
+	void validateProductsExist() {
+		// given
+		productRepository.save(후라이드치킨_상품());
+
+		// when
+		menuValidator.validateProductsExist(Collections.singletonList(MenuProductDto.from(후라이드치킨_2개_메뉴_상품())));
+
+		// then
+	}
+
+	@DisplayName("상품이 존재하는지 검증한다. (실패)")
+	@Test
+	void validateProductsExistFail() {
+		// given
+
+		// when
+		ThrowingCallable throwingCallable = () -> menuValidator.validateProductsExist(
+			Collections.singletonList(MenuProductDto.from(후라이드치킨_2개_메뉴_상품())));
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("메뉴 가격이 메뉴 상품들의 총 가격 보다 작거나 같은지 검증한다.")
+	@Test
+	void validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPrice() {
+		// given
+		productRepository.save(후라이드치킨_상품());
+
+		// when
+		menuValidator.validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPrice(
+			Price.from(BigDecimal.valueOf(10000)),
+			Collections.singletonList(MenuProductDto.from(후라이드치킨_2개_메뉴_상품())));
+
+		// then
+	}
+
+	@DisplayName("메뉴 가격이 메뉴 상품들의 총 가격 보다 작거나 같은지 검증한다. (실패)")
+	@Test
+	void validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPriceFail() {
+		// given
+		productRepository.save(후라이드치킨_상품());
+
+		// when
+		ThrowingCallable throwingCallable = () -> menuValidator.validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPrice(
+			Price.from(BigDecimal.valueOf(100000)),
+			Collections.singletonList(MenuProductDto.from(후라이드치킨_2개_메뉴_상품())));
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/kitchenpos/menu/domain/PriceInvalidMenuValidator.java
+++ b/src/test/java/kitchenpos/menu/domain/PriceInvalidMenuValidator.java
@@ -1,0 +1,26 @@
+package kitchenpos.menu.domain;
+
+import java.util.List;
+
+import kitchenpos.common.domain.Price;
+import kitchenpos.menu.dto.MenuProductDto;
+
+public class PriceInvalidMenuValidator implements MenuValidator {
+	@Override
+	public void validateMenuGroupExist(Long menuGroupId) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateProductsExist(List<MenuProductDto> menuProductDto) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPrice(
+		Price price,
+		List<MenuProductDto> menuProductDto
+	) {
+		throw new IllegalArgumentException();
+	}
+}

--- a/src/test/java/kitchenpos/menu/domain/ValidMenuValidator.java
+++ b/src/test/java/kitchenpos/menu/domain/ValidMenuValidator.java
@@ -1,0 +1,26 @@
+package kitchenpos.menu.domain;
+
+import java.util.List;
+
+import kitchenpos.common.domain.Price;
+import kitchenpos.menu.dto.MenuProductDto;
+
+public class ValidMenuValidator implements MenuValidator {
+	@Override
+	public void validateMenuGroupExist(Long menuGroupId) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateProductsExist(List<MenuProductDto> menuProductDto) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateMenuPriceIsLessThanOrEqualToTotalMenuProductsPrice(
+		Price price,
+		List<MenuProductDto> menuProductDto
+	) {
+		// do not throw exception
+	}
+}

--- a/src/test/java/kitchenpos/menu/infra/repository/InMemoryMenuRepository.java
+++ b/src/test/java/kitchenpos/menu/infra/repository/InMemoryMenuRepository.java
@@ -1,0 +1,39 @@
+package kitchenpos.menu.infra.repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import kitchenpos.menu.domain.Menu;
+import kitchenpos.menu.domain.MenuRepository;
+
+public class InMemoryMenuRepository implements MenuRepository {
+	private final Map<Long, Menu> menus = new HashMap<>();
+
+	@Override
+	public List<Menu> findAll() {
+		return new ArrayList<>(menus.values());
+	}
+
+	@Override
+	public Menu save(Menu menu) {
+		menus.put(menu.getId(), menu);
+		return menu;
+	}
+
+	@Override
+	public Optional<Menu> findById(Long id) {
+		return Optional.ofNullable(menus.get(id));
+	}
+
+	@Override
+	public List<Menu> findAllByIdIn(List<Long> ids) {
+		return menus.values()
+			.stream()
+			.filter(menu -> ids.contains(menu.getId()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/test/java/kitchenpos/menugroup/MenuGroupFixture.java
+++ b/src/test/java/kitchenpos/menugroup/MenuGroupFixture.java
@@ -1,8 +1,14 @@
 package kitchenpos.menugroup;
 
+import kitchenpos.common.domain.Name;
+import kitchenpos.menugroup.domain.MenuGroup;
 import kitchenpos.menugroup.dto.MenuGroupCreateRequest;
 
 public class MenuGroupFixture {
+	public static MenuGroup 추천_메뉴_그룹() {
+		return MenuGroup.of(1L, Name.from("추천메뉴"));
+	}
+
 	public static MenuGroupCreateRequest 추천_메뉴_그룹_요청() {
 		return new MenuGroupCreateRequest("추천메뉴");
 	}

--- a/src/test/java/kitchenpos/menugroup/domain/MenuGroupTest.java
+++ b/src/test/java/kitchenpos/menugroup/domain/MenuGroupTest.java
@@ -12,12 +12,12 @@ class MenuGroupTest {
 
 	@DisplayName("생성")
 	@Test
-	void of() {
+	void from() {
 		// given
-		Name name = Name.of("추천 메뉴");
+		Name name = Name.from("추천 메뉴");
 
 		// when
-		MenuGroup menuGroup = MenuGroup.of(name);
+		MenuGroup menuGroup = MenuGroup.from(name);
 
 		// then
 		assertThat(menuGroup.getName()).isEqualTo(name);

--- a/src/test/java/kitchenpos/menugroup/infra/repository/InMemoryMenuGroupRepository.java
+++ b/src/test/java/kitchenpos/menugroup/infra/repository/InMemoryMenuGroupRepository.java
@@ -1,0 +1,30 @@
+package kitchenpos.menugroup.infra.repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import kitchenpos.menugroup.domain.MenuGroup;
+import kitchenpos.menugroup.domain.MenuGroupRepository;
+
+public class InMemoryMenuGroupRepository implements MenuGroupRepository {
+	private final Map<Long, MenuGroup> menuGroups = new HashMap<>();
+
+	@Override
+	public MenuGroup save(MenuGroup menuGroup) {
+		menuGroups.put(menuGroup.getId(), menuGroup);
+		return menuGroup;
+	}
+
+	@Override
+	public List<MenuGroup> findAll() {
+		return new ArrayList<>(menuGroups.values());
+	}
+
+	@Override
+	public Optional<MenuGroup> findById(Long id) {
+		return Optional.ofNullable(menuGroups.get(id));
+	}
+}

--- a/src/test/java/kitchenpos/order/OrderFixture.java
+++ b/src/test/java/kitchenpos/order/OrderFixture.java
@@ -1,12 +1,25 @@
 package kitchenpos.order;
 
+import static kitchenpos.order.OrderLineItemFixture.*;
+import static kitchenpos.ordertable.OrderTableFixture.*;
+
 import java.util.Collections;
 
+import kitchenpos.order.domain.Order;
 import kitchenpos.order.domain.OrderStatus;
+import kitchenpos.order.domain.ValidOrderValidator;
 import kitchenpos.order.dto.OrderLineItemDto;
 import kitchenpos.order.dto.OrderRequest;
 
 public class OrderFixture {
+	public static Order 후라이드후라이드_메뉴_주문() {
+		return Order.of(
+			1L,
+			비어있지않은_주문_테이블_1번().getId(),
+			Collections.singletonList(OrderLineItemDto.from(후라이드후라이드_메뉴_주문_항목())),
+			new ValidOrderValidator());
+	}
+
 	public static OrderRequest 주문_요청(Long orderTableId, Long menuId, int quantity) {
 		return new OrderRequest(orderTableId, Collections.singletonList(new OrderLineItemDto(menuId, quantity)));
 	}

--- a/src/test/java/kitchenpos/order/OrderFixture.java
+++ b/src/test/java/kitchenpos/order/OrderFixture.java
@@ -10,12 +10,21 @@ import kitchenpos.order.domain.OrderStatus;
 import kitchenpos.order.domain.ValidOrderValidator;
 import kitchenpos.order.dto.OrderLineItemDto;
 import kitchenpos.order.dto.OrderRequest;
+import kitchenpos.ordertable.domain.OrderTable;
 
 public class OrderFixture {
 	public static Order 후라이드후라이드_메뉴_주문() {
 		return Order.of(
 			1L,
 			비어있지않은_주문_테이블_1번().getId(),
+			Collections.singletonList(OrderLineItemDto.from(후라이드후라이드_메뉴_주문_항목())),
+			new ValidOrderValidator());
+	}
+
+	public static Order 후라이드후라이드_메뉴_주문(OrderTable orderTable) {
+		return Order.of(
+			2L,
+			orderTable.getId(),
 			Collections.singletonList(OrderLineItemDto.from(후라이드후라이드_메뉴_주문_항목())),
 			new ValidOrderValidator());
 	}

--- a/src/test/java/kitchenpos/order/OrderLineItemFixture.java
+++ b/src/test/java/kitchenpos/order/OrderLineItemFixture.java
@@ -1,0 +1,12 @@
+package kitchenpos.order;
+
+import static kitchenpos.menu.MenuFixture.*;
+
+import kitchenpos.common.domain.Quantity;
+import kitchenpos.order.domain.OrderLineItem;
+
+public class OrderLineItemFixture {
+	public static OrderLineItem 후라이드후라이드_메뉴_주문_항목() {
+		return OrderLineItem.of(1L, 후라이드후라이드_메뉴().getId(), Quantity.from(1L));
+	}
+}

--- a/src/test/java/kitchenpos/order/domain/OrderLineItemTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderLineItemTest.java
@@ -20,10 +20,10 @@ class OrderLineItemTest {
 		Quantity quantity = Quantity.from(1L);
 
 		// when
-		OrderLineItem orderLineItem = OrderLineItem.of(menu, quantity);
+		OrderLineItem orderLineItem = OrderLineItem.of(menu.getId(), quantity);
 
 		// then
-		assertThat(orderLineItem.getMenu()).isEqualTo(menu);
+		assertThat(orderLineItem.getMenuId()).isEqualTo(menu.getId());
 		assertThat(orderLineItem.getQuantity()).isEqualTo(quantity);
 	}
 }

--- a/src/test/java/kitchenpos/order/domain/OrderLineItemTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderLineItemTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.order.domain;
 
+import static kitchenpos.menugroup.MenuGroupFixture.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.math.BigDecimal;
@@ -14,7 +15,6 @@ import kitchenpos.common.domain.Quantity;
 import kitchenpos.menu.domain.Menu;
 import kitchenpos.menu.domain.MenuProduct;
 import kitchenpos.menu.domain.MenuProducts;
-import kitchenpos.menugroup.domain.MenuGroup;
 import kitchenpos.product.domain.Product;
 
 @DisplayName("주문 항목")
@@ -27,7 +27,7 @@ class OrderLineItemTest {
 		Menu menu = Menu.of(
 			Name.from("후라이드+후라이드"),
 			Price.from(BigDecimal.valueOf(25000)),
-			MenuGroup.from(Name.from("추천메뉴")),
+			추천_메뉴_그룹().getId(),
 			MenuProducts.from(Collections.singletonList(
 				MenuProduct.of(
 					Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),

--- a/src/test/java/kitchenpos/order/domain/OrderLineItemTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderLineItemTest.java
@@ -25,14 +25,14 @@ class OrderLineItemTest {
 	void of() {
 		// given
 		Menu menu = Menu.of(
-			Name.of("후라이드+후라이드"),
-			Price.of(BigDecimal.valueOf(25000)),
-			MenuGroup.of(Name.of("추천메뉴")),
-			MenuProducts.of(Collections.singletonList(
+			Name.from("후라이드+후라이드"),
+			Price.from(BigDecimal.valueOf(25000)),
+			MenuGroup.from(Name.from("추천메뉴")),
+			MenuProducts.from(Collections.singletonList(
 				MenuProduct.of(
-					Product.of(Name.of("후라이드치킨"), Price.of(BigDecimal.valueOf(17000))),
-					Quantity.of(2L)))));
-		Quantity quantity = Quantity.of(1L);
+					Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
+					Quantity.from(2L)))));
+		Quantity quantity = Quantity.from(1L);
 
 		// when
 		OrderLineItem orderLineItem = OrderLineItem.of(menu, quantity);

--- a/src/test/java/kitchenpos/order/domain/OrderLineItemTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderLineItemTest.java
@@ -1,21 +1,13 @@
 package kitchenpos.order.domain;
 
-import static kitchenpos.menugroup.MenuGroupFixture.*;
+import static kitchenpos.menu.MenuFixture.*;
 import static org.assertj.core.api.Assertions.*;
-
-import java.math.BigDecimal;
-import java.util.Collections;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Name;
-import kitchenpos.common.domain.Price;
 import kitchenpos.common.domain.Quantity;
 import kitchenpos.menu.domain.Menu;
-import kitchenpos.menu.domain.MenuProduct;
-import kitchenpos.menu.domain.MenuProducts;
-import kitchenpos.product.domain.Product;
 
 @DisplayName("주문 항목")
 class OrderLineItemTest {
@@ -24,14 +16,7 @@ class OrderLineItemTest {
 	@Test
 	void of() {
 		// given
-		Menu menu = Menu.of(
-			Name.from("후라이드+후라이드"),
-			Price.from(BigDecimal.valueOf(25000)),
-			추천_메뉴_그룹().getId(),
-			MenuProducts.from(Collections.singletonList(
-				MenuProduct.of(
-					Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
-					Quantity.from(2L)))));
+		Menu menu = 후라이드후라이드_메뉴();
 		Quantity quantity = Quantity.from(1L);
 
 		// when

--- a/src/test/java/kitchenpos/order/domain/OrderLineItemsTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderLineItemsTest.java
@@ -1,6 +1,6 @@
 package kitchenpos.order.domain;
 
-import static kitchenpos.menu.MenuFixture.*;
+import static kitchenpos.order.OrderLineItemFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 
@@ -12,17 +12,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
-import kitchenpos.common.domain.Quantity;
-
 @DisplayName("주문 항목들")
 class OrderLineItemsTest {
 	@DisplayName("생성")
 	@Test
 	void from() {
 		// given
-		OrderLineItem orderLineItem = OrderLineItem.of(
-			후라이드후라이드_메뉴(),
-			Quantity.from(1L));
+		OrderLineItem orderLineItem = 후라이드후라이드_메뉴_주문_항목();
 
 		// when
 		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(orderLineItem));

--- a/src/test/java/kitchenpos/order/domain/OrderLineItemsTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderLineItemsTest.java
@@ -25,21 +25,21 @@ import kitchenpos.product.domain.Product;
 class OrderLineItemsTest {
 	@DisplayName("생성")
 	@Test
-	void of() {
+	void from() {
 		// given
 		OrderLineItem orderLineItem = OrderLineItem.of(
 			Menu.of(
-				Name.of("후라이드+후라이드"),
-				Price.of(BigDecimal.valueOf(25000)),
-				MenuGroup.of(Name.of("추천메뉴")),
-				MenuProducts.of(Collections.singletonList(
+				Name.from("후라이드+후라이드"),
+				Price.from(BigDecimal.valueOf(25000)),
+				MenuGroup.from(Name.from("추천메뉴")),
+				MenuProducts.from(Collections.singletonList(
 					MenuProduct.of(
-						Product.of(Name.of("후라이드치킨"), Price.of(BigDecimal.valueOf(17000))),
-						Quantity.of(2L))))),
-			Quantity.of(1L));
+						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
+						Quantity.from(2L))))),
+			Quantity.from(1L));
 
 		// when
-		OrderLineItems orderLineItems = OrderLineItems.of(Collections.singletonList(orderLineItem));
+		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(orderLineItem));
 
 		// then
 		assertThat(orderLineItems).isNotNull();
@@ -48,11 +48,11 @@ class OrderLineItemsTest {
 	@DisplayName("생성 실패 - 주문 항목이 없는 경우")
 	@ParameterizedTest
 	@NullAndEmptySource
-	void ofFailOnEmptyOrderLineItem(List<OrderLineItem> orderLineItems) {
+	void fromFailOnEmptyOrderLineItem(List<OrderLineItem> orderLineItems) {
 		// given
 
 		// when
-		ThrowingCallable throwingCallable = () -> OrderLineItems.of(orderLineItems);
+		ThrowingCallable throwingCallable = () -> OrderLineItems.from(orderLineItems);
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/kitchenpos/order/domain/OrderLineItemsTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderLineItemsTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.order.domain;
 
+import static kitchenpos.menugroup.MenuGroupFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 
@@ -18,7 +19,6 @@ import kitchenpos.common.domain.Quantity;
 import kitchenpos.menu.domain.Menu;
 import kitchenpos.menu.domain.MenuProduct;
 import kitchenpos.menu.domain.MenuProducts;
-import kitchenpos.menugroup.domain.MenuGroup;
 import kitchenpos.product.domain.Product;
 
 @DisplayName("주문 항목들")
@@ -31,7 +31,7 @@ class OrderLineItemsTest {
 			Menu.of(
 				Name.from("후라이드+후라이드"),
 				Price.from(BigDecimal.valueOf(25000)),
-				MenuGroup.from(Name.from("추천메뉴")),
+				추천_메뉴_그룹().getId(),
 				MenuProducts.from(Collections.singletonList(
 					MenuProduct.of(
 						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),

--- a/src/test/java/kitchenpos/order/domain/OrderLineItemsTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderLineItemsTest.java
@@ -1,10 +1,9 @@
 package kitchenpos.order.domain;
 
-import static kitchenpos.menugroup.MenuGroupFixture.*;
+import static kitchenpos.menu.MenuFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 
@@ -13,13 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
-import kitchenpos.common.domain.Name;
-import kitchenpos.common.domain.Price;
 import kitchenpos.common.domain.Quantity;
-import kitchenpos.menu.domain.Menu;
-import kitchenpos.menu.domain.MenuProduct;
-import kitchenpos.menu.domain.MenuProducts;
-import kitchenpos.product.domain.Product;
 
 @DisplayName("주문 항목들")
 class OrderLineItemsTest {
@@ -28,14 +21,7 @@ class OrderLineItemsTest {
 	void from() {
 		// given
 		OrderLineItem orderLineItem = OrderLineItem.of(
-			Menu.of(
-				Name.from("후라이드+후라이드"),
-				Price.from(BigDecimal.valueOf(25000)),
-				추천_메뉴_그룹().getId(),
-				MenuProducts.from(Collections.singletonList(
-					MenuProduct.of(
-						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
-						Quantity.from(2L))))),
+			후라이드후라이드_메뉴(),
 			Quantity.from(1L));
 
 		// when

--- a/src/test/java/kitchenpos/order/domain/OrderTableEmptyOrderValidator.java
+++ b/src/test/java/kitchenpos/order/domain/OrderTableEmptyOrderValidator.java
@@ -1,0 +1,17 @@
+package kitchenpos.order.domain;
+
+import java.util.List;
+
+import kitchenpos.order.dto.OrderLineItemDto;
+
+public class OrderTableEmptyOrderValidator implements OrderValidator {
+	@Override
+	public void validateOrderTableExistAndNotEmpty(Long orderTableId) {
+		throw new IllegalArgumentException();
+	}
+
+	@Override
+	public void validateMenusExist(List<OrderLineItemDto> orderLineItemDtos) {
+		// do not throw exception
+	}
+}

--- a/src/test/java/kitchenpos/order/domain/OrderTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderTest.java
@@ -1,25 +1,17 @@
 package kitchenpos.order.domain;
 
-import static kitchenpos.menugroup.MenuGroupFixture.*;
+import static kitchenpos.menu.MenuFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 
-import java.math.BigDecimal;
 import java.util.Collections;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Name;
-import kitchenpos.common.domain.Price;
 import kitchenpos.common.domain.Quantity;
-import kitchenpos.menu.domain.Menu;
-import kitchenpos.menu.domain.MenuProduct;
-import kitchenpos.menu.domain.MenuProducts;
-import kitchenpos.menugroup.domain.MenuGroup;
 import kitchenpos.ordertable.domain.NumberOfGuests;
 import kitchenpos.ordertable.domain.OrderTable;
-import kitchenpos.product.domain.Product;
 
 @DisplayName("주문")
 class OrderTest {
@@ -29,14 +21,7 @@ class OrderTest {
 		// given
 		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
 		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
-			Menu.of(
-				Name.from("후라이드+후라이드"),
-				Price.from(BigDecimal.valueOf(25000)),
-				추천_메뉴_그룹().getId(),
-				MenuProducts.from(Collections.singletonList(
-					MenuProduct.of(
-						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
-						Quantity.from(2L))))),
+			후라이드후라이드_메뉴(),
 			Quantity.from(1L))));
 
 		// when
@@ -52,14 +37,7 @@ class OrderTest {
 		// given
 		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), true);
 		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
-			Menu.of(
-				Name.from("후라이드+후라이드"),
-				Price.from(BigDecimal.valueOf(25000)),
-				추천_메뉴_그룹().getId(),
-				MenuProducts.from(Collections.singletonList(
-					MenuProduct.of(
-						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
-						Quantity.from(2L))))),
+			후라이드후라이드_메뉴(),
 			Quantity.from(1L))));
 
 		// when

--- a/src/test/java/kitchenpos/order/domain/OrderTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.order.domain;
 
+import static kitchenpos.menugroup.MenuGroupFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 
@@ -31,7 +32,7 @@ class OrderTest {
 			Menu.of(
 				Name.from("후라이드+후라이드"),
 				Price.from(BigDecimal.valueOf(25000)),
-				MenuGroup.from(Name.from("추천메뉴")),
+				추천_메뉴_그룹().getId(),
 				MenuProducts.from(Collections.singletonList(
 					MenuProduct.of(
 						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
@@ -54,7 +55,7 @@ class OrderTest {
 			Menu.of(
 				Name.from("후라이드+후라이드"),
 				Price.from(BigDecimal.valueOf(25000)),
-				MenuGroup.from(Name.from("추천메뉴")),
+				추천_메뉴_그룹().getId(),
 				MenuProducts.from(Collections.singletonList(
 					MenuProduct.of(
 						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),

--- a/src/test/java/kitchenpos/order/domain/OrderTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderTest.java
@@ -1,16 +1,17 @@
 package kitchenpos.order.domain;
 
-import static kitchenpos.menu.MenuFixture.*;
+import static kitchenpos.order.OrderLineItemFixture.*;
+import static kitchenpos.ordertable.OrderTableFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Quantity;
-import kitchenpos.ordertable.domain.NumberOfGuests;
+import kitchenpos.order.dto.OrderLineItemDto;
 import kitchenpos.ordertable.domain.OrderTable;
 
 @DisplayName("주문")
@@ -19,13 +20,15 @@ class OrderTest {
 	@Test
 	void of() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
-		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
-			후라이드후라이드_메뉴(),
-			Quantity.from(1L))));
+		OrderTable orderTable = 비어있지않은_주문_테이블_1번();
+		List<OrderLineItemDto> orderLineItemDtos = Collections.singletonList(
+			OrderLineItemDto.from(후라이드후라이드_메뉴_주문_항목()));
 
 		// when
-		Order order = Order.of(orderTable, orderLineItems);
+		Order order = Order.of(
+			orderTable.getId(),
+			orderLineItemDtos,
+			new ValidOrderValidator());
 
 		// then
 		assertThat(order).isNotNull();
@@ -35,13 +38,15 @@ class OrderTest {
 	@Test
 	void ofFailOnEmptyOrderTable() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
-			후라이드후라이드_메뉴(),
-			Quantity.from(1L))));
+		OrderTable orderTable = 비어있지않은_주문_테이블_1번();
+		List<OrderLineItemDto> orderLineItemDtos = Collections.singletonList(
+			OrderLineItemDto.from(후라이드후라이드_메뉴_주문_항목()));
 
 		// when
-		ThrowingCallable throwingCallable = () -> Order.of(orderTable, orderLineItems);
+		ThrowingCallable throwingCallable = () -> Order.of(
+			orderTable.getOrderTableGroupId(),
+			orderLineItemDtos,
+			new OrderTableEmptyOrderValidator());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/kitchenpos/order/domain/OrderTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderTest.java
@@ -26,17 +26,17 @@ class OrderTest {
 	@Test
 	void of() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.of(4), false);
-		OrderLineItems orderLineItems = OrderLineItems.of(Collections.singletonList(OrderLineItem.of(
+		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
+		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
 			Menu.of(
-				Name.of("후라이드+후라이드"),
-				Price.of(BigDecimal.valueOf(25000)),
-				MenuGroup.of(Name.of("추천메뉴")),
-				MenuProducts.of(Collections.singletonList(
+				Name.from("후라이드+후라이드"),
+				Price.from(BigDecimal.valueOf(25000)),
+				MenuGroup.from(Name.from("추천메뉴")),
+				MenuProducts.from(Collections.singletonList(
 					MenuProduct.of(
-						Product.of(Name.of("후라이드치킨"), Price.of(BigDecimal.valueOf(17000))),
-						Quantity.of(2L))))),
-			Quantity.of(1L))));
+						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
+						Quantity.from(2L))))),
+			Quantity.from(1L))));
 
 		// when
 		Order order = Order.of(orderTable, orderLineItems);
@@ -49,17 +49,17 @@ class OrderTest {
 	@Test
 	void ofFailOnEmptyOrderTable() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderLineItems orderLineItems = OrderLineItems.of(Collections.singletonList(OrderLineItem.of(
+		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
 			Menu.of(
-				Name.of("후라이드+후라이드"),
-				Price.of(BigDecimal.valueOf(25000)),
-				MenuGroup.of(Name.of("추천메뉴")),
-				MenuProducts.of(Collections.singletonList(
+				Name.from("후라이드+후라이드"),
+				Price.from(BigDecimal.valueOf(25000)),
+				MenuGroup.from(Name.from("추천메뉴")),
+				MenuProducts.from(Collections.singletonList(
 					MenuProduct.of(
-						Product.of(Name.of("후라이드치킨"), Price.of(BigDecimal.valueOf(17000))),
-						Quantity.of(2L))))),
-			Quantity.of(1L))));
+						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
+						Quantity.from(2L))))),
+			Quantity.from(1L))));
 
 		// when
 		ThrowingCallable throwingCallable = () -> Order.of(orderTable, orderLineItems);

--- a/src/test/java/kitchenpos/order/domain/OrderValidatorTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderValidatorTest.java
@@ -64,11 +64,11 @@ class OrderValidatorTest {
 	@Test
 	void validateOrderTableExistAndNotEmptyFailOnEmpty() {
 		// given
-		orderTableRepository.save(빈_주문_테이블_2번());
+		orderTableRepository.save(빈_주문_테이블_3번());
 
 		// when
 		ThrowingCallable throwingCallable = () -> orderValidator.validateOrderTableExistAndNotEmpty(
-			빈_주문_테이블_2번().getId());
+			빈_주문_테이블_3번().getId());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/kitchenpos/order/domain/OrderValidatorTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderValidatorTest.java
@@ -1,0 +1,100 @@
+package kitchenpos.order.domain;
+
+import static kitchenpos.menu.MenuFixture.*;
+import static kitchenpos.order.OrderLineItemFixture.*;
+import static kitchenpos.ordertable.OrderTableFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kitchenpos.menu.domain.MenuRepository;
+import kitchenpos.menu.infra.repository.InMemoryMenuRepository;
+import kitchenpos.order.dto.OrderLineItemDto;
+import kitchenpos.order.infra.MenusImpl;
+import kitchenpos.order.infra.OrderTablesImpl;
+import kitchenpos.ordertable.domain.OrderTableRepository;
+import kitchenpos.ordertable.infra.repository.InMemoryOrderTableRepository;
+
+class OrderValidatorTest {
+	private OrderTableRepository orderTableRepository;
+	private MenuRepository menuRepository;
+	private OrderValidator orderValidator;
+
+	@BeforeEach
+	void setUp() {
+		orderTableRepository = new InMemoryOrderTableRepository();
+		menuRepository = new InMemoryMenuRepository();
+		orderValidator = new OrderValidatorImpl(
+			new OrderTablesImpl(orderTableRepository),
+			new MenusImpl(menuRepository));
+	}
+
+	@DisplayName("주문 테이블이 존재하고 비어있지 않은지 검증한다.")
+	@Test
+	void validateOrderTableExistAndNotEmpty() {
+		// given
+		orderTableRepository.save(비어있지않은_주문_테이블_1번());
+
+		// when
+		orderValidator.validateOrderTableExistAndNotEmpty(비어있지않은_주문_테이블_1번().getId());
+
+		// then
+	}
+
+	@DisplayName("주문 테이블이 존재하고 비어있지 않은지 검증한다. (실패) - 존재하지 않는 주문 테이블")
+	@Test
+	void validateOrderTableExistAndNotEmptyFailOnNotExist() {
+		// given
+
+		// when
+		ThrowingCallable throwingCallable = () -> orderValidator.validateOrderTableExistAndNotEmpty(
+			비어있지않은_주문_테이블_1번().getId());
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("주문 테이블이 존재하고 비어있지 않은지 검증한다. (실패) - 빈 테이블")
+	@Test
+	void validateOrderTableExistAndNotEmptyFailOnEmpty() {
+		// given
+		orderTableRepository.save(빈_주문_테이블_2번());
+
+		// when
+		ThrowingCallable throwingCallable = () -> orderValidator.validateOrderTableExistAndNotEmpty(
+			빈_주문_테이블_2번().getId());
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("메뉴가 존재하는지 검증한다.")
+	@Test
+	void validateMenusExist() {
+		// given
+		menuRepository.save(후라이드후라이드_메뉴());
+
+		// when
+		orderValidator.validateMenusExist(Collections.singletonList(OrderLineItemDto.from(후라이드후라이드_메뉴_주문_항목())));
+
+		// then
+	}
+
+	@DisplayName("메뉴가 존재하는지 검증한다. (실패)")
+	@Test
+	void validateMenusExistFail() {
+		// given
+
+		// when
+		ThrowingCallable throwingCallable = () -> orderValidator.validateMenusExist(
+			Collections.singletonList(OrderLineItemDto.from(후라이드후라이드_메뉴_주문_항목())));
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/kitchenpos/order/domain/OrderValidatorTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderValidatorTest.java
@@ -20,6 +20,7 @@ import kitchenpos.order.infra.OrderTablesImpl;
 import kitchenpos.ordertable.domain.OrderTableRepository;
 import kitchenpos.ordertable.infra.repository.InMemoryOrderTableRepository;
 
+@DisplayName("주문 검증자")
 class OrderValidatorTest {
 	private OrderTableRepository orderTableRepository;
 	private MenuRepository menuRepository;

--- a/src/test/java/kitchenpos/order/domain/ValidOrderValidator.java
+++ b/src/test/java/kitchenpos/order/domain/ValidOrderValidator.java
@@ -1,0 +1,17 @@
+package kitchenpos.order.domain;
+
+import java.util.List;
+
+import kitchenpos.order.dto.OrderLineItemDto;
+
+public class ValidOrderValidator implements OrderValidator {
+	@Override
+	public void validateOrderTableExistAndNotEmpty(Long orderTableId) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateMenusExist(List<OrderLineItemDto> orderLineItemDtos) {
+		// do not throw exception
+	}
+}

--- a/src/test/java/kitchenpos/order/infra/repository/InMemoryOrderRepository.java
+++ b/src/test/java/kitchenpos/order/infra/repository/InMemoryOrderRepository.java
@@ -1,0 +1,40 @@
+package kitchenpos.order.infra.repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import kitchenpos.order.domain.Order;
+import kitchenpos.order.domain.OrderRepository;
+
+public class InMemoryOrderRepository implements OrderRepository {
+	private final Map<Long, Order> orders = new HashMap<>();
+
+	@Override
+	public Order save(Order order) {
+		orders.put(order.getId(), order);
+		return order;
+	}
+
+	@Override
+	public List<Order> findAll() {
+		return new ArrayList<>(orders.values());
+	}
+
+	@Override
+	public Optional<Order> findById(Long id) {
+		return Optional.ofNullable(orders.get(id));
+	}
+
+	@Override
+	public List<Order> findByOrderTableId(Long orderTableId) {
+		return orders.values()
+			.stream()
+			.filter(order -> Objects.equals(order.getOrderTableId(), orderTableId))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/test/java/kitchenpos/ordertable/OrderTableFixture.java
+++ b/src/test/java/kitchenpos/ordertable/OrderTableFixture.java
@@ -1,8 +1,18 @@
 package kitchenpos.ordertable;
 
+import kitchenpos.ordertable.domain.NumberOfGuests;
+import kitchenpos.ordertable.domain.OrderTable;
 import kitchenpos.ordertable.dto.OrderTableRequest;
 
 public class OrderTableFixture {
+	public static OrderTable 비어있지않은_주문_테이블_1번() {
+		return OrderTable.of(1L, NumberOfGuests.from(4), false);
+	}
+
+	public static OrderTable 빈_주문_테이블_2번() {
+		return OrderTable.of(2L, NumberOfGuests.from(0), true);
+	}
+
 	public static OrderTableRequest 빈_주문_테이블_요청() {
 		return new OrderTableRequest(4, true);
 	}

--- a/src/test/java/kitchenpos/ordertable/OrderTableFixture.java
+++ b/src/test/java/kitchenpos/ordertable/OrderTableFixture.java
@@ -13,6 +13,10 @@ public class OrderTableFixture {
 		return OrderTable.of(2L, NumberOfGuests.from(0), true);
 	}
 
+	public static OrderTable 주문_테이블_그룹에_속한_주문_테이블_3번() {
+		return OrderTable.of(3L, NumberOfGuests.from(0), true);
+	}
+
 	public static OrderTableRequest 빈_주문_테이블_요청() {
 		return new OrderTableRequest(4, true);
 	}

--- a/src/test/java/kitchenpos/ordertable/OrderTableFixture.java
+++ b/src/test/java/kitchenpos/ordertable/OrderTableFixture.java
@@ -6,15 +6,27 @@ import kitchenpos.ordertable.dto.OrderTableRequest;
 
 public class OrderTableFixture {
 	public static OrderTable 비어있지않은_주문_테이블_1번() {
-		return OrderTable.of(1L, NumberOfGuests.from(4), false);
+		return OrderTable.of(1L, null, NumberOfGuests.from(4), false);
 	}
 
-	public static OrderTable 빈_주문_테이블_2번() {
-		return OrderTable.of(2L, NumberOfGuests.from(0), true);
+	public static OrderTable 비어있지않은_주문_테이블_2번() {
+		return OrderTable.of(2L, null, NumberOfGuests.from(4), false);
 	}
 
-	public static OrderTable 주문_테이블_그룹에_속한_주문_테이블_3번() {
-		return OrderTable.of(3L, NumberOfGuests.from(0), true);
+	public static OrderTable 빈_주문_테이블_3번() {
+		return OrderTable.of(3L, null, NumberOfGuests.from(0), true);
+	}
+
+	public static OrderTable 빈_주문_테이블_4번() {
+		return OrderTable.of(4L, null, NumberOfGuests.from(0), true);
+	}
+
+	public static OrderTable 그룹핑된_주문_테이블_5번() {
+		return OrderTable.of(5L, 1L, NumberOfGuests.from(0), true);
+	}
+
+	public static OrderTable 그룹핑된_주문_테이블_6번() {
+		return OrderTable.of(6L, 1L, NumberOfGuests.from(0), true);
 	}
 
 	public static OrderTableRequest 빈_주문_테이블_요청() {

--- a/src/test/java/kitchenpos/ordertable/domain/NotCompletedOrderExistOrderTableValidator.java
+++ b/src/test/java/kitchenpos/ordertable/domain/NotCompletedOrderExistOrderTableValidator.java
@@ -1,0 +1,8 @@
+package kitchenpos.ordertable.domain;
+
+public class NotCompletedOrderExistOrderTableValidator implements OrderTableValidator {
+	@Override
+	public void validateNotCompletedOrderNotExist(Long id) {
+		throw new IllegalStateException();
+	}
+}

--- a/src/test/java/kitchenpos/ordertable/domain/NumberOfGuestsTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/NumberOfGuestsTest.java
@@ -15,11 +15,11 @@ class NumberOfGuestsTest {
 	@DisplayName("생성")
 	@ParameterizedTest
 	@ValueSource(strings = {"0", "4"})
-	void of(int value) {
+	void from(int value) {
 		// given
 
 		// when
-		NumberOfGuests numberOfGuests = NumberOfGuests.of(value);
+		NumberOfGuests numberOfGuests = NumberOfGuests.from(value);
 
 		// then
 		assertThat(numberOfGuests.getValue()).isEqualTo(value);
@@ -29,11 +29,11 @@ class NumberOfGuestsTest {
 	@ParameterizedTest
 	@NullSource
 	@ValueSource(strings = {"-1"})
-	void ofFailOnNullOrNegativeNumberOfGuests(Integer value) {
+	void fromFailOnNullOrNegativeNumberOfGuests(Integer value) {
 		// given
 
 		// when
-		ThrowingCallable throwingCallable = () -> NumberOfGuests.of(value);
+		ThrowingCallable throwingCallable = () -> NumberOfGuests.from(value);
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -46,8 +46,8 @@ class NumberOfGuestsTest {
 		int value = 4;
 
 		// when
-		NumberOfGuests aNumberOfGuests = NumberOfGuests.of(value);
-		NumberOfGuests bNumberOfGuests = NumberOfGuests.of(value);
+		NumberOfGuests aNumberOfGuests = NumberOfGuests.from(value);
+		NumberOfGuests bNumberOfGuests = NumberOfGuests.from(value);
 
 		// then
 		assertThat(aNumberOfGuests).isEqualTo(bNumberOfGuests);

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
@@ -1,6 +1,6 @@
 package kitchenpos.ordertable.domain;
 
-import static kitchenpos.menu.MenuFixture.*;
+import static kitchenpos.order.OrderLineItemFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,9 +11,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Quantity;
 import kitchenpos.order.domain.Order;
-import kitchenpos.order.domain.OrderLineItem;
 import kitchenpos.order.domain.OrderLineItems;
 import kitchenpos.ordertablegroup.domain.OrderTableGroup;
 
@@ -69,11 +67,9 @@ class OrderTableTest {
 	void changeEmptyFailOnOrderNotCompleted() {
 		// given
 		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
-		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
-			후라이드후라이드_메뉴(),
-			Quantity.from(1L))));
-
-		Order.of(orderTable, orderLineItems);
+		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(후라이드후라이드_메뉴_주문_항목()));
+		// TODO : fix this
+		// Order.of(orderTable, orderLineItems);
 
 		// when
 		ThrowingCallable throwingCallable = () -> orderTable.changeEmpty(true);

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
@@ -1,15 +1,12 @@
 package kitchenpos.ordertable.domain;
 
+import static kitchenpos.ordertable.OrderTableFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Arrays;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import kitchenpos.ordertablegroup.domain.OrderTableGroup;
 
 @DisplayName("주문 테이블")
 class OrderTableTest {
@@ -34,7 +31,7 @@ class OrderTableTest {
 	@Test
 	void changeEmpty() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
+		OrderTable orderTable = 비어있지않은_주문_테이블_1번();
 
 		// when
 		orderTable.changeEmpty(true, new ValidOrderTableValidator());
@@ -47,12 +44,10 @@ class OrderTableTest {
 	@Test
 	void changeEmptyFailOnBelongToOrderTableGroup() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
+		OrderTable orderTable = 그룹핑된_주문_테이블_5번();
 
 		// when
-		ThrowingCallable throwingCallable = () -> orderTable1.changeEmpty(true, new ValidOrderTableValidator());
+		ThrowingCallable throwingCallable = () -> orderTable.changeEmpty(true, new ValidOrderTableValidator());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalStateException.class);
@@ -62,7 +57,7 @@ class OrderTableTest {
 	@Test
 	void changeEmptyFailOnOrderNotCompleted() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
+		OrderTable orderTable = 비어있지않은_주문_테이블_1번();
 
 		// when
 		ThrowingCallable throwingCallable = () -> orderTable.changeEmpty(
@@ -77,7 +72,7 @@ class OrderTableTest {
 	@Test
 	void changeNumberOfGuests() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
+		OrderTable orderTable = 비어있지않은_주문_테이블_1번();
 		NumberOfGuests numberOfGuests = NumberOfGuests.from(6);
 
 		// when
@@ -91,7 +86,7 @@ class OrderTableTest {
 	@Test
 	void changeNumberOfGuestsFailOnEmpty() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTable orderTable = 빈_주문_테이블_3번();
 		NumberOfGuests numberOfGuests = NumberOfGuests.from(6);
 
 		// when

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
@@ -1,18 +1,14 @@
 package kitchenpos.ordertable.domain;
 
-import static kitchenpos.order.OrderLineItemFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.order.domain.Order;
-import kitchenpos.order.domain.OrderLineItems;
 import kitchenpos.ordertablegroup.domain.OrderTableGroup;
 
 @DisplayName("주문 테이블")
@@ -41,7 +37,7 @@ class OrderTableTest {
 		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
 
 		// when
-		orderTable.changeEmpty(true);
+		orderTable.changeEmpty(true, new ValidOrderTableValidator());
 
 		// then
 		assertThat(orderTable.isEmpty()).isEqualTo(true);
@@ -56,7 +52,7 @@ class OrderTableTest {
 		OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
 
 		// when
-		ThrowingCallable throwingCallable = () -> orderTable1.changeEmpty(true);
+		ThrowingCallable throwingCallable = () -> orderTable1.changeEmpty(true, new ValidOrderTableValidator());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalStateException.class);
@@ -67,12 +63,11 @@ class OrderTableTest {
 	void changeEmptyFailOnOrderNotCompleted() {
 		// given
 		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
-		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(후라이드후라이드_메뉴_주문_항목()));
-		// TODO : fix this
-		// Order.of(orderTable, orderLineItems);
 
 		// when
-		ThrowingCallable throwingCallable = () -> orderTable.changeEmpty(true);
+		ThrowingCallable throwingCallable = () -> orderTable.changeEmpty(
+			true,
+			new NotCompletedOrderExistOrderTableValidator());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalStateException.class);

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.ordertable.domain;
 
+import static kitchenpos.menugroup.MenuGroupFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,7 +18,6 @@ import kitchenpos.common.domain.Quantity;
 import kitchenpos.menu.domain.Menu;
 import kitchenpos.menu.domain.MenuProduct;
 import kitchenpos.menu.domain.MenuProducts;
-import kitchenpos.menugroup.domain.MenuGroup;
 import kitchenpos.order.domain.Order;
 import kitchenpos.order.domain.OrderLineItem;
 import kitchenpos.order.domain.OrderLineItems;
@@ -80,7 +80,7 @@ class OrderTableTest {
 			Menu.of(
 				Name.from("후라이드+후라이드"),
 				Price.from(BigDecimal.valueOf(25000)),
-				MenuGroup.from(Name.from("추천메뉴")),
+				추천_메뉴_그룹().getId(),
 				MenuProducts.from(Collections.singletonList(
 					MenuProduct.of(
 						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
@@ -31,7 +31,7 @@ class OrderTableTest {
 	@Test
 	void of() {
 		// given
-		NumberOfGuests numberOfGuests = NumberOfGuests.of(4);
+		NumberOfGuests numberOfGuests = NumberOfGuests.from(4);
 		boolean empty = false;
 
 		// when
@@ -47,7 +47,7 @@ class OrderTableTest {
 	@Test
 	void changeEmpty() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.of(4), false);
+		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
 
 		// when
 		orderTable.changeEmpty(true);
@@ -60,9 +60,9 @@ class OrderTableTest {
 	@Test
 	void changeEmptyFailOnBelongToOrderTableGroup() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTableGroup.of(Arrays.asList(orderTable1, orderTable2));
+		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
 
 		// when
 		ThrowingCallable throwingCallable = () -> orderTable1.changeEmpty(true);
@@ -75,17 +75,17 @@ class OrderTableTest {
 	@Test
 	void changeEmptyFailOnOrderNotCompleted() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.of(4), false);
-		OrderLineItems orderLineItems = OrderLineItems.of(Collections.singletonList(OrderLineItem.of(
+		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
+		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
 			Menu.of(
-				Name.of("후라이드+후라이드"),
-				Price.of(BigDecimal.valueOf(25000)),
-				MenuGroup.of(Name.of("추천메뉴")),
-				MenuProducts.of(Collections.singletonList(
+				Name.from("후라이드+후라이드"),
+				Price.from(BigDecimal.valueOf(25000)),
+				MenuGroup.from(Name.from("추천메뉴")),
+				MenuProducts.from(Collections.singletonList(
 					MenuProduct.of(
-						Product.of(Name.of("후라이드치킨"), Price.of(BigDecimal.valueOf(17000))),
-						Quantity.of(2L))))),
-			Quantity.of(1L))));
+						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
+						Quantity.from(2L))))),
+			Quantity.from(1L))));
 
 		Order.of(orderTable, orderLineItems);
 
@@ -100,8 +100,8 @@ class OrderTableTest {
 	@Test
 	void changeNumberOfGuests() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.of(4), false);
-		NumberOfGuests numberOfGuests = NumberOfGuests.of(6);
+		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
+		NumberOfGuests numberOfGuests = NumberOfGuests.from(6);
 
 		// when
 		orderTable.changeNumberOfGuests(numberOfGuests);
@@ -114,8 +114,8 @@ class OrderTableTest {
 	@Test
 	void changeNumberOfGuestsFailOnEmpty() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.of(4), true);
-		NumberOfGuests numberOfGuests = NumberOfGuests.of(6);
+		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), true);
+		NumberOfGuests numberOfGuests = NumberOfGuests.from(6);
 
 		// when
 		ThrowingCallable throwingCallable = () -> orderTable.changeNumberOfGuests(numberOfGuests);

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTableTest.java
@@ -1,10 +1,9 @@
 package kitchenpos.ordertable.domain;
 
-import static kitchenpos.menugroup.MenuGroupFixture.*;
+import static kitchenpos.menu.MenuFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -12,17 +11,11 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Name;
-import kitchenpos.common.domain.Price;
 import kitchenpos.common.domain.Quantity;
-import kitchenpos.menu.domain.Menu;
-import kitchenpos.menu.domain.MenuProduct;
-import kitchenpos.menu.domain.MenuProducts;
 import kitchenpos.order.domain.Order;
 import kitchenpos.order.domain.OrderLineItem;
 import kitchenpos.order.domain.OrderLineItems;
 import kitchenpos.ordertablegroup.domain.OrderTableGroup;
-import kitchenpos.product.domain.Product;
 
 @DisplayName("주문 테이블")
 class OrderTableTest {
@@ -77,14 +70,7 @@ class OrderTableTest {
 		// given
 		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), false);
 		OrderLineItems orderLineItems = OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
-			Menu.of(
-				Name.from("후라이드+후라이드"),
-				Price.from(BigDecimal.valueOf(25000)),
-				추천_메뉴_그룹().getId(),
-				MenuProducts.from(Collections.singletonList(
-					MenuProduct.of(
-						Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
-						Quantity.from(2L))))),
+			후라이드후라이드_메뉴(),
 			Quantity.from(1L))));
 
 		Order.of(orderTable, orderLineItems);

--- a/src/test/java/kitchenpos/ordertable/domain/OrderTableValidatorTest.java
+++ b/src/test/java/kitchenpos/ordertable/domain/OrderTableValidatorTest.java
@@ -1,0 +1,55 @@
+package kitchenpos.ordertable.domain;
+
+import static kitchenpos.order.OrderFixture.*;
+import static kitchenpos.ordertable.OrderTableFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.ThrowableAssert.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kitchenpos.order.domain.Order;
+import kitchenpos.order.domain.OrderRepository;
+import kitchenpos.order.domain.OrderStatus;
+import kitchenpos.order.infra.repository.InMemoryOrderRepository;
+import kitchenpos.ordertable.infra.OrdersImpl;
+
+@DisplayName("주문 테이블 검증자")
+public class OrderTableValidatorTest {
+	private OrderRepository orderRepository;
+	private OrderTableValidator orderTableValidator;
+
+	@BeforeEach
+	void setUp() {
+		orderRepository = new InMemoryOrderRepository();
+		orderTableValidator = new OrderTableValidatorImpl(new OrdersImpl(orderRepository));
+	}
+
+	@DisplayName("완료되지 않은 주문이 없는지 검증한다.")
+	@Test
+	void validateNotCompletedOrderNotExist() {
+		// given
+		Order order = orderRepository.save(후라이드후라이드_메뉴_주문());
+		order.changeOrderStatus(OrderStatus.COMPLETION);
+
+		// when
+		orderTableValidator.validateNotCompletedOrderNotExist(비어있지않은_주문_테이블_1번().getId());
+
+		// then
+	}
+
+	@DisplayName("완료되지 않은 주문이 없는지 검증한다. (실패)")
+	@Test
+	void validateNotCompletedOrderNotExistFail() {
+		// given
+		orderRepository.save(후라이드후라이드_메뉴_주문());
+
+		// when
+		ThrowingCallable throwingCallable = () -> orderTableValidator.validateNotCompletedOrderNotExist(
+			비어있지않은_주문_테이블_1번().getId());
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalStateException.class);
+	}
+}

--- a/src/test/java/kitchenpos/ordertable/domain/ValidOrderTableValidator.java
+++ b/src/test/java/kitchenpos/ordertable/domain/ValidOrderTableValidator.java
@@ -1,0 +1,8 @@
+package kitchenpos.ordertable.domain;
+
+public class ValidOrderTableValidator implements OrderTableValidator {
+	@Override
+	public void validateNotCompletedOrderNotExist(Long id) {
+		// do not throw exception
+	}
+}

--- a/src/test/java/kitchenpos/ordertable/infra/repository/InMemoryOrderTableRepository.java
+++ b/src/test/java/kitchenpos/ordertable/infra/repository/InMemoryOrderTableRepository.java
@@ -1,0 +1,39 @@
+package kitchenpos.ordertable.infra.repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import kitchenpos.ordertable.domain.OrderTable;
+import kitchenpos.ordertable.domain.OrderTableRepository;
+
+public class InMemoryOrderTableRepository implements OrderTableRepository {
+	private final Map<Long, OrderTable> orderTables = new HashMap<>();
+
+	@Override
+	public OrderTable save(OrderTable orderTable) {
+		orderTables.put(orderTable.getId(), orderTable);
+		return orderTable;
+	}
+
+	@Override
+	public List<OrderTable> findAll() {
+		return new ArrayList<>(orderTables.values());
+	}
+
+	@Override
+	public Optional<OrderTable> findById(Long id) {
+		return Optional.ofNullable(orderTables.get(id));
+	}
+
+	@Override
+	public List<OrderTable> findAllByIdIn(List<Long> ids) {
+		return orderTables.values()
+			.stream()
+			.filter(orderTable -> ids.contains(orderTable.getId()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/test/java/kitchenpos/ordertable/infra/repository/InMemoryOrderTableRepository.java
+++ b/src/test/java/kitchenpos/ordertable/infra/repository/InMemoryOrderTableRepository.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,14 @@ public class InMemoryOrderTableRepository implements OrderTableRepository {
 		return orderTables.values()
 			.stream()
 			.filter(orderTable -> ids.contains(orderTable.getId()))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public List<OrderTable> findByOrderTableGroupId(Long orderTableGroupId) {
+		return orderTables.values()
+			.stream()
+			.filter(orderTable -> Objects.equals(orderTable.getOrderTableGroupId(), orderTableGroupId))
 			.collect(Collectors.toList());
 	}
 }

--- a/src/test/java/kitchenpos/ordertablegroup/OrderTableGroupFixture.java
+++ b/src/test/java/kitchenpos/ordertablegroup/OrderTableGroupFixture.java
@@ -2,9 +2,17 @@ package kitchenpos.ordertablegroup;
 
 import java.util.List;
 
+import kitchenpos.ordertablegroup.domain.OrderTableGroup;
+import kitchenpos.ordertablegroup.domain.ValidOrderTableGroupValidator;
 import kitchenpos.ordertablegroup.dto.OrderTableGroupCreateRequest;
 
 public class OrderTableGroupFixture {
+	public static OrderTableGroup 주문_테이블_그룹(List<Long> orderTableIds) {
+		OrderTableGroup orderTableGroup = OrderTableGroup.from(1L);
+		orderTableGroup.group(orderTableIds, new ValidOrderTableGroupValidator());
+		return orderTableGroup;
+	}
+
 	public static OrderTableGroupCreateRequest 주문_테이블_그룹_요청(List<Long> orderTableIds) {
 		return new OrderTableGroupCreateRequest(orderTableIds);
 	}

--- a/src/test/java/kitchenpos/ordertablegroup/domain/AlreadyGroupedOrderTableGroupValidator.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/AlreadyGroupedOrderTableGroupValidator.java
@@ -1,0 +1,25 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public class AlreadyGroupedOrderTableGroupValidator implements OrderTableGroupValidator {
+	@Override
+	public void validateOrderTablesAreGreaterThanOrEqualToTwo(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateNotGrouped(List<Long> orderTableIds) {
+		throw new IllegalArgumentException();
+	}
+
+	@Override
+	public void validateOrderTableIsEmpty(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateNotCompletedOrderNotExist(Long orderTableGroupId) {
+		// do not throw exception
+	}
+}

--- a/src/test/java/kitchenpos/ordertablegroup/domain/CountInvalidOrderTableGroupValidator.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/CountInvalidOrderTableGroupValidator.java
@@ -1,0 +1,25 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public class CountInvalidOrderTableGroupValidator implements OrderTableGroupValidator {
+	@Override
+	public void validateOrderTablesAreGreaterThanOrEqualToTwo(List<Long> orderTableIds) {
+		throw new IllegalArgumentException();
+	}
+
+	@Override
+	public void validateNotGrouped(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateOrderTableIsEmpty(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateNotCompletedOrderNotExist(Long orderTableGroupId) {
+		// do not throw exception
+	}
+}

--- a/src/test/java/kitchenpos/ordertablegroup/domain/NotCompletedOrderExistOrderTableGroupValidator.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/NotCompletedOrderExistOrderTableGroupValidator.java
@@ -1,0 +1,25 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public class NotCompletedOrderExistOrderTableGroupValidator implements OrderTableGroupValidator {
+	@Override
+	public void validateOrderTablesAreGreaterThanOrEqualToTwo(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateNotGrouped(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateOrderTableIsEmpty(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateNotCompletedOrderNotExist(Long orderTableGroupId) {
+		throw new IllegalStateException();
+	}
+}

--- a/src/test/java/kitchenpos/ordertablegroup/domain/NotEmptyOrderTableGroupValidator.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/NotEmptyOrderTableGroupValidator.java
@@ -1,0 +1,25 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public class NotEmptyOrderTableGroupValidator implements OrderTableGroupValidator {
+	@Override
+	public void validateOrderTablesAreGreaterThanOrEqualToTwo(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateNotGrouped(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateOrderTableIsEmpty(List<Long> orderTableIds) {
+		throw new IllegalArgumentException();
+	}
+
+	@Override
+	public void validateNotCompletedOrderNotExist(Long orderTableGroupId) {
+		// do not throw exception
+	}
+}

--- a/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
@@ -30,13 +30,13 @@ class OrderTableGroupTest {
 
 	@DisplayName("생성")
 	@Test
-	void of() {
+	void from() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.of(4), true);
+		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
 
 		// when
-		OrderTableGroup orderTableGroup = OrderTableGroup.of(Arrays.asList(
+		OrderTableGroup orderTableGroup = OrderTableGroup.from(Arrays.asList(
 			orderTable1,
 			orderTable2));
 
@@ -46,12 +46,12 @@ class OrderTableGroupTest {
 
 	@DisplayName("생성 실패 - 주문 테이블이 2개 미만인 경우")
 	@Test
-	void ofFailOnLessThenTwo() {
+	void fromFailOnLessThenTwo() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.of(4), true);
+		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), true);
 
 		// when
-		ThrowingCallable throwingCallable = () -> OrderTableGroup.of(Collections.singletonList(orderTable));
+		ThrowingCallable throwingCallable = () -> OrderTableGroup.from(Collections.singletonList(orderTable));
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -59,15 +59,15 @@ class OrderTableGroupTest {
 
 	@DisplayName("생성 실패 - 이미 주문 테이블 그룹이 있는 경우")
 	@Test
-	void ofFailOnAlreadyHavingOrderTableGroup() {
+	void fromFailOnAlreadyHavingOrderTableGroup() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTable orderTable3 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTableGroup.of(Arrays.asList(orderTable1, orderTable2));
+		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTable orderTable3 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
 
 		// when
-		ThrowingCallable throwingCallable = () -> OrderTableGroup.of(Arrays.asList(orderTable1, orderTable3));
+		ThrowingCallable throwingCallable = () -> OrderTableGroup.from(Arrays.asList(orderTable1, orderTable3));
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -75,13 +75,13 @@ class OrderTableGroupTest {
 
 	@DisplayName("생성 실패 - 주문 테이블이 비어있지 않은 경우")
 	@Test
-	void ofFailOnNotEmpty() {
+	void fromFailOnNotEmpty() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.of(4), false);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.of(4), false);
+		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), false);
+		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), false);
 
 		// when
-		ThrowingCallable throwingCallable = () -> OrderTableGroup.of(Arrays.asList(orderTable1, orderTable2));
+		ThrowingCallable throwingCallable = () -> OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -91,9 +91,9 @@ class OrderTableGroupTest {
 	@Test
 	void ungroup() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTableGroup orderTableGroup = OrderTableGroup.of(Arrays.asList(orderTable1, orderTable2));
+		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTableGroup orderTableGroup = OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
 
 		// when
 		orderTableGroup.ungroup();
@@ -109,20 +109,20 @@ class OrderTableGroupTest {
 	@Test
 	void ungroupFailOnHavingNotCompletedOrder() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.of(4), true);
-		OrderTableGroup orderTableGroup = OrderTableGroup.of(Arrays.asList(orderTable1, orderTable2));
+		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTableGroup orderTableGroup = OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
 		Order.of(orderTable1,
-			OrderLineItems.of(Collections.singletonList(OrderLineItem.of(
+			OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
 				Menu.of(
-					Name.of("후라이드+후라이드"),
-					Price.of(BigDecimal.valueOf(25000)),
-					MenuGroup.of(Name.of("추천메뉴")),
-					MenuProducts.of(Collections.singletonList(
+					Name.from("후라이드+후라이드"),
+					Price.from(BigDecimal.valueOf(25000)),
+					MenuGroup.from(Name.from("추천메뉴")),
+					MenuProducts.from(Collections.singletonList(
 						MenuProduct.of(
-							Product.of(Name.of("후라이드치킨"), Price.of(BigDecimal.valueOf(17000))),
-							Quantity.of(2L))))),
-				Quantity.of(1L)))));
+							Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
+							Quantity.from(2L))))),
+				Quantity.from(1L)))));
 
 		// when
 		ThrowingCallable throwingCallable = orderTableGroup::ungroup;

--- a/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.ordertablegroup.domain;
 
+import static kitchenpos.menugroup.MenuGroupFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,7 +18,6 @@ import kitchenpos.common.domain.Quantity;
 import kitchenpos.menu.domain.Menu;
 import kitchenpos.menu.domain.MenuProduct;
 import kitchenpos.menu.domain.MenuProducts;
-import kitchenpos.menugroup.domain.MenuGroup;
 import kitchenpos.order.domain.Order;
 import kitchenpos.order.domain.OrderLineItem;
 import kitchenpos.order.domain.OrderLineItems;
@@ -117,7 +117,7 @@ class OrderTableGroupTest {
 				Menu.of(
 					Name.from("후라이드+후라이드"),
 					Price.from(BigDecimal.valueOf(25000)),
-					MenuGroup.from(Name.from("추천메뉴")),
+					추천_메뉴_그룹().getId(),
 					MenuProducts.from(Collections.singletonList(
 						MenuProduct.of(
 							Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),

--- a/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
@@ -1,29 +1,22 @@
 package kitchenpos.ordertablegroup.domain;
 
-import static kitchenpos.menugroup.MenuGroupFixture.*;
+import static kitchenpos.menu.MenuFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Name;
-import kitchenpos.common.domain.Price;
 import kitchenpos.common.domain.Quantity;
-import kitchenpos.menu.domain.Menu;
-import kitchenpos.menu.domain.MenuProduct;
-import kitchenpos.menu.domain.MenuProducts;
 import kitchenpos.order.domain.Order;
 import kitchenpos.order.domain.OrderLineItem;
 import kitchenpos.order.domain.OrderLineItems;
 import kitchenpos.ordertable.domain.NumberOfGuests;
 import kitchenpos.ordertable.domain.OrderTable;
-import kitchenpos.product.domain.Product;
 
 @DisplayName("주문 테이블 그룹")
 class OrderTableGroupTest {
@@ -114,14 +107,7 @@ class OrderTableGroupTest {
 		OrderTableGroup orderTableGroup = OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
 		Order.of(orderTable1,
 			OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
-				Menu.of(
-					Name.from("후라이드+후라이드"),
-					Price.from(BigDecimal.valueOf(25000)),
-					추천_메뉴_그룹().getId(),
-					MenuProducts.from(Collections.singletonList(
-						MenuProduct.of(
-							Product.of(Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(17000))),
-							Quantity.from(2L))))),
+				후라이드후라이드_메뉴(),
 				Quantity.from(1L)))));
 
 		// when

--- a/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
@@ -1,9 +1,8 @@
 package kitchenpos.ordertablegroup.domain;
 
-import static kitchenpos.order.OrderLineItemFixture.*;
+import static kitchenpos.ordertable.OrderTableFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,38 +10,35 @@ import java.util.Collections;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.order.domain.Order;
-import kitchenpos.order.domain.OrderLineItems;
-import kitchenpos.ordertable.domain.NumberOfGuests;
-import kitchenpos.ordertable.domain.OrderTable;
-
 @DisplayName("주문 테이블 그룹")
 class OrderTableGroupTest {
 
-	@DisplayName("생성")
+	@DisplayName("그룹 생성")
 	@Test
-	void from() {
+	void group() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTableGroup orderTableGroup = OrderTableGroup.newInstance();
 
 		// when
-		OrderTableGroup orderTableGroup = OrderTableGroup.from(Arrays.asList(
-			orderTable1,
-			orderTable2));
+		orderTableGroup.group(Arrays.asList(
+				빈_주문_테이블_3번().getId(),
+				빈_주문_테이블_4번().getId()),
+			new ValidOrderTableGroupValidator());
 
 		// then
 		assertThat(orderTableGroup).isNotNull();
 	}
 
-	@DisplayName("생성 실패 - 주문 테이블이 2개 미만인 경우")
+	@DisplayName("그룹 생성 실패 - 주문 테이블이 2개 미만인 경우")
 	@Test
-	void fromFailOnLessThenTwo() {
+	void groupFailOnLessThenTwo() {
 		// given
-		OrderTable orderTable = OrderTable.of(NumberOfGuests.from(4), true);
+		OrderTableGroup orderTableGroup = OrderTableGroup.newInstance();
 
 		// when
-		ThrowingCallable throwingCallable = () -> OrderTableGroup.from(Collections.singletonList(orderTable));
+		ThrowingCallable throwingCallable = () -> orderTableGroup.group(Collections.singletonList(
+				빈_주문_테이블_3번().getId()),
+			new CountInvalidOrderTableGroupValidator());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -50,15 +46,15 @@ class OrderTableGroupTest {
 
 	@DisplayName("생성 실패 - 이미 주문 테이블 그룹이 있는 경우")
 	@Test
-	void fromFailOnAlreadyHavingOrderTableGroup() {
+	void groupFailOnAlreadyHavingOrderTableGroup() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTable orderTable3 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
+		OrderTableGroup orderTableGroup = OrderTableGroup.newInstance();
 
 		// when
-		ThrowingCallable throwingCallable = () -> OrderTableGroup.from(Arrays.asList(orderTable1, orderTable3));
+		ThrowingCallable throwingCallable = () -> orderTableGroup.group(Arrays.asList(
+				빈_주문_테이블_3번().getId(),
+				그룹핑된_주문_테이블_5번().getId()),
+			new AlreadyGroupedOrderTableGroupValidator());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -66,13 +62,15 @@ class OrderTableGroupTest {
 
 	@DisplayName("생성 실패 - 주문 테이블이 비어있지 않은 경우")
 	@Test
-	void fromFailOnNotEmpty() {
+	void groupFailOnNotEmpty() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), false);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), false);
+		OrderTableGroup orderTableGroup = OrderTableGroup.newInstance();
 
 		// when
-		ThrowingCallable throwingCallable = () -> OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
+		ThrowingCallable throwingCallable = () -> orderTableGroup.group(Arrays.asList(
+				비어있지않은_주문_테이블_1번().getId(),
+				빈_주문_테이블_3번().getId()),
+			new NotEmptyOrderTableGroupValidator());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
@@ -82,32 +80,31 @@ class OrderTableGroupTest {
 	@Test
 	void ungroup() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTableGroup orderTableGroup = OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
+		OrderTableGroup orderTableGroup = OrderTableGroup.newInstance();
+		orderTableGroup.group(Arrays.asList(
+				빈_주문_테이블_3번().getId(),
+				빈_주문_테이블_4번().getId()),
+			new ValidOrderTableGroupValidator());
 
 		// when
-		orderTableGroup.ungroup();
+		orderTableGroup.ungroup(new ValidOrderTableGroupValidator());
 
 		// then
-		assertAll(
-			() -> assertThat(orderTableGroup.getOrderTables()).isEmpty(),
-			() -> assertThat(orderTable1.getOrderTableGroup()).isNull(),
-			() -> assertThat(orderTable2.getOrderTableGroup()).isNull());
 	}
 
 	@DisplayName("그룹 해제 실패 - 주문 테이블에 완료되지 않은 주문이 있는 경우")
 	@Test
 	void ungroupFailOnHavingNotCompletedOrder() {
 		// given
-		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
-		OrderTableGroup orderTableGroup = OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
-		// TODO : fix this
-		// Order.of(orderTable1, OrderLineItems.from(Collections.singletonList(후라이드후라이드_메뉴_주문_항목())));
+		OrderTableGroup orderTableGroup = OrderTableGroup.newInstance();
+		orderTableGroup.group(Arrays.asList(
+				빈_주문_테이블_3번().getId(),
+				빈_주문_테이블_4번().getId()),
+			new ValidOrderTableGroupValidator());
 
 		// when
-		ThrowingCallable throwingCallable = orderTableGroup::ungroup;
+		ThrowingCallable throwingCallable = () -> orderTableGroup.ungroup(
+			new NotCompletedOrderExistOrderTableGroupValidator());
 
 		// then
 		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalStateException.class);

--- a/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupTest.java
@@ -1,6 +1,6 @@
 package kitchenpos.ordertablegroup.domain;
 
-import static kitchenpos.menu.MenuFixture.*;
+import static kitchenpos.order.OrderLineItemFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.ThrowableAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,9 +11,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import kitchenpos.common.domain.Quantity;
 import kitchenpos.order.domain.Order;
-import kitchenpos.order.domain.OrderLineItem;
 import kitchenpos.order.domain.OrderLineItems;
 import kitchenpos.ordertable.domain.NumberOfGuests;
 import kitchenpos.ordertable.domain.OrderTable;
@@ -105,10 +103,8 @@ class OrderTableGroupTest {
 		OrderTable orderTable1 = OrderTable.of(NumberOfGuests.from(4), true);
 		OrderTable orderTable2 = OrderTable.of(NumberOfGuests.from(4), true);
 		OrderTableGroup orderTableGroup = OrderTableGroup.from(Arrays.asList(orderTable1, orderTable2));
-		Order.of(orderTable1,
-			OrderLineItems.from(Collections.singletonList(OrderLineItem.of(
-				후라이드후라이드_메뉴(),
-				Quantity.from(1L)))));
+		// TODO : fix this
+		// Order.of(orderTable1, OrderLineItems.from(Collections.singletonList(후라이드후라이드_메뉴_주문_항목())));
 
 		// when
 		ThrowingCallable throwingCallable = orderTableGroup::ungroup;

--- a/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupValidatorTest.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/OrderTableGroupValidatorTest.java
@@ -1,0 +1,164 @@
+package kitchenpos.ordertablegroup.domain;
+
+import static kitchenpos.order.OrderFixture.*;
+import static kitchenpos.ordertable.OrderTableFixture.*;
+import static kitchenpos.ordertablegroup.OrderTableGroupFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.ThrowableAssert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kitchenpos.order.domain.Order;
+import kitchenpos.order.domain.OrderRepository;
+import kitchenpos.order.domain.OrderStatus;
+import kitchenpos.order.infra.repository.InMemoryOrderRepository;
+import kitchenpos.ordertable.domain.OrderTable;
+import kitchenpos.ordertable.domain.OrderTableRepository;
+import kitchenpos.ordertable.domain.ValidOrderTableValidator;
+import kitchenpos.ordertable.infra.repository.InMemoryOrderTableRepository;
+import kitchenpos.ordertablegroup.infra.OrderTablesImpl;
+import kitchenpos.ordertablegroup.infra.OrdersImpl;
+
+@DisplayName("주문 테이블 그룹 검증자")
+public class OrderTableGroupValidatorTest {
+	private OrderTableRepository orderTableRepository;
+	private OrderRepository orderRepository;
+	private OrderTableGroupValidator orderTableGroupValidator;
+
+	@BeforeEach
+	void setUp() {
+		orderTableRepository = new InMemoryOrderTableRepository();
+		orderRepository = new InMemoryOrderRepository();
+		orderTableGroupValidator = new OrderTableGroupValidatorImpl(
+			new OrderTablesImpl(orderTableRepository),
+			new OrdersImpl(orderRepository));
+	}
+
+	@DisplayName("주문 테이블이 2개 이상인지 검증한다.")
+	@Test
+	void validateOrderTablesAreGreaterThanOrEqualToTwo() {
+		// given
+		orderTableRepository.save(빈_주문_테이블_3번());
+		orderTableRepository.save(빈_주문_테이블_4번());
+
+		// when
+		orderTableGroupValidator.validateOrderTablesAreGreaterThanOrEqualToTwo(
+			Arrays.asList(빈_주문_테이블_3번().getId(), 빈_주문_테이블_4번().getId()));
+
+		// then
+	}
+
+	@DisplayName("주문 테이블이 2개 이상인지 검증한다. (실패)")
+	@Test
+	void validateOrderTablesAreGreaterThanOrEqualToTwoFail() {
+		// given
+		orderTableRepository.save(빈_주문_테이블_3번());
+
+		// when
+		ThrowingCallable throwingCallable = () -> orderTableGroupValidator.validateOrderTablesAreGreaterThanOrEqualToTwo(
+			Collections.singletonList(빈_주문_테이블_3번().getId()));
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("주문 테이블이 그룹핑되어 있지 않은지 검증한다.")
+	@Test
+	void validateNotGrouped() {
+		// given
+		orderTableRepository.save(빈_주문_테이블_3번());
+		orderTableRepository.save(빈_주문_테이블_4번());
+
+		// when
+		orderTableGroupValidator.validateNotGrouped(
+			Arrays.asList(빈_주문_테이블_3번().getId(), 빈_주문_테이블_4번().getId()));
+
+		// then
+	}
+
+	@DisplayName("주문 테이블이 그룹핑되어 있지 않은지 검증한다. (실패)")
+	@Test
+	void validateNotGroupedFail() {
+		// given
+		orderTableRepository.save(빈_주문_테이블_3번()).groupedBy(1L);
+		orderTableRepository.save(빈_주문_테이블_4번()).groupedBy(1L);
+
+		// when
+		ThrowingCallable throwingCallable = () -> orderTableGroupValidator.validateNotGrouped(
+			Arrays.asList(빈_주문_테이블_3번().getId(), 빈_주문_테이블_4번().getId()));
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("주문 테이블이 비어있는지 검증한다.")
+	@Test
+	void validateOrderTableIsNotEmpty() {
+		// given
+		orderTableRepository.save(빈_주문_테이블_3번());
+		orderTableRepository.save(빈_주문_테이블_4번());
+
+		// when
+		orderTableGroupValidator.validateOrderTableIsEmpty(
+			Arrays.asList(빈_주문_테이블_3번().getId(), 빈_주문_테이블_4번().getId()));
+
+		// then
+	}
+
+	@DisplayName("주문 테이블이 비어있는지 검증한다. (실패)")
+	@Test
+	void validateOrderTableIsNotEmptyFail() {
+		// given
+		orderTableRepository.save(빈_주문_테이블_3번()).changeEmpty(false, new ValidOrderTableValidator());
+		orderTableRepository.save(빈_주문_테이블_4번());
+
+		// when
+		ThrowingCallable throwingCallable = () -> orderTableGroupValidator.validateOrderTableIsEmpty(
+			Arrays.asList(빈_주문_테이블_3번().getId(), 빈_주문_테이블_4번().getId()));
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("완료되지 않은 주문이 없는지 검증한다.")
+	@Test
+	void validateNotCompletedOrderNotExist() {
+		// given
+		OrderTable orderTable1 = orderTableRepository.save(빈_주문_테이블_3번());
+		OrderTable orderTable2 = orderTableRepository.save(빈_주문_테이블_4번());
+		OrderTableGroup orderTableGroup = 주문_테이블_그룹(Arrays.asList(orderTable1.getId(), orderTable2.getId()));
+		orderTable1.groupedBy(orderTableGroup.getId());
+		orderTable2.groupedBy(orderTableGroup.getId());
+		Order order = orderRepository.save(후라이드후라이드_메뉴_주문(orderTable1));
+		order.changeOrderStatus(OrderStatus.COMPLETION);
+
+		// when
+		orderTableGroupValidator.validateNotCompletedOrderNotExist(orderTableGroup.getId());
+
+		// then
+	}
+
+	@DisplayName("완료되지 않은 주문이 없는지 검증한다. (실패)")
+	@Test
+	void validateNotCompletedOrderNotExistFail() {
+		// given
+		OrderTable orderTable1 = orderTableRepository.save(빈_주문_테이블_3번());
+		OrderTable orderTable2 = orderTableRepository.save(빈_주문_테이블_4번());
+		OrderTableGroup orderTableGroup = 주문_테이블_그룹(Arrays.asList(orderTable1.getId(), orderTable2.getId()));
+		orderTable1.groupedBy(orderTableGroup.getId());
+		orderTable2.groupedBy(orderTableGroup.getId());
+		Order order = orderRepository.save(후라이드후라이드_메뉴_주문(orderTable1));
+
+		// when
+		ThrowingCallable throwingCallable = () -> orderTableGroupValidator.validateNotCompletedOrderNotExist(
+			orderTableGroup.getId());
+
+		// then
+		assertThatThrownBy(throwingCallable).isInstanceOf(IllegalStateException.class);
+	}
+}

--- a/src/test/java/kitchenpos/ordertablegroup/domain/ValidOrderTableGroupValidator.java
+++ b/src/test/java/kitchenpos/ordertablegroup/domain/ValidOrderTableGroupValidator.java
@@ -1,0 +1,25 @@
+package kitchenpos.ordertablegroup.domain;
+
+import java.util.List;
+
+public class ValidOrderTableGroupValidator implements OrderTableGroupValidator {
+	@Override
+	public void validateOrderTablesAreGreaterThanOrEqualToTwo(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateNotGrouped(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateOrderTableIsEmpty(List<Long> orderTableIds) {
+		// do not throw exception
+	}
+
+	@Override
+	public void validateNotCompletedOrderNotExist(Long orderTableGroupId) {
+		// do not throw exception
+	}
+}

--- a/src/test/java/kitchenpos/product/ProductFixture.java
+++ b/src/test/java/kitchenpos/product/ProductFixture.java
@@ -2,9 +2,24 @@ package kitchenpos.product;
 
 import java.math.BigDecimal;
 
+import kitchenpos.common.domain.Name;
+import kitchenpos.common.domain.Price;
+import kitchenpos.product.domain.Product;
 import kitchenpos.product.dto.ProductCreateRequest;
 
 public class ProductFixture {
+	public static Product 후라이드치킨_상품() {
+		return Product.of(1L, Name.from("후라이드치킨"), Price.from(BigDecimal.valueOf(16000L)));
+	}
+
+	public static Product 강정치킨_상품() {
+		return Product.of(2L, Name.from("강정치킨"), Price.from(BigDecimal.valueOf(17000L)));
+	}
+
+	public static Product 양념치킨_상품() {
+		return Product.of(3L, Name.from("양념치킨"), Price.from(BigDecimal.valueOf(18000L)));
+	}
+
 	public static ProductCreateRequest 후라이드치킨_상품_요청() {
 		return new ProductCreateRequest("후라이드치킨", BigDecimal.valueOf(16000L));
 	}

--- a/src/test/java/kitchenpos/product/domain/ProductTest.java
+++ b/src/test/java/kitchenpos/product/domain/ProductTest.java
@@ -17,8 +17,8 @@ class ProductTest {
 	@Test
 	void of() {
 		// given
-		Name name = Name.of("강정치킨");
-		Price price = Price.of(BigDecimal.valueOf(17000));
+		Name name = Name.from("강정치킨");
+		Price price = Price.from(BigDecimal.valueOf(17000));
 
 		// when
 		Product product = Product.of(name, price);

--- a/src/test/java/kitchenpos/product/infra/repository/InMemoryProductRepository.java
+++ b/src/test/java/kitchenpos/product/infra/repository/InMemoryProductRepository.java
@@ -1,0 +1,39 @@
+package kitchenpos.product.infra.repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import kitchenpos.product.domain.Product;
+import kitchenpos.product.domain.ProductRepository;
+
+public class InMemoryProductRepository implements ProductRepository {
+	private final Map<Long, Product> products = new HashMap<>();
+
+	@Override
+	public Product save(Product products) {
+		this.products.put(products.getId(), products);
+		return products;
+	}
+
+	@Override
+	public List<Product> findAll() {
+		return new ArrayList<>(products.values());
+	}
+
+	@Override
+	public Optional<Product> findById(Long id) {
+		return Optional.ofNullable(products.get(id));
+	}
+
+	@Override
+	public List<Product> findAllByIdIn(List<Long> ids) {
+		return products.values()
+			.stream()
+			.filter(product -> ids.contains(product.getId()))
+			.collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
안녕하세요, 리뷰어님

> 의존성 리팩터링 전 (도메인 패키지)
![image](https://user-images.githubusercontent.com/45726850/147450051-af8357c0-03d6-4f2e-8567-9914e22f2661.png)

위의 그림이 기존의 도메인 간 연관관계로 인한 의존성을 보여주고 있는데요
검은색 형광펜으로 칠한 부분이 라이프사이클을 같이 가져간다고 생각하여
하나의 애그리게잇으로 구성하고 나머지는 의존성을 끊어 내도록 작업했습니다.

그래서 아래의 총 6개의 애그리게잇을 구성했구요,

- 메뉴 그룹 : MenuGroup
- 메뉴 : Menu, MenuProduct
- 상품 : Product
- 주문 : Order, OrderLineItem
- 주문 테이블 : OrderTable
- 주문 테이블 그룹 : OrderTableGroup

> 의존성 리팩터링 후 (도메인 패키지)
![image](https://user-images.githubusercontent.com/45726850/147449910-4f27da7a-340a-4340-986a-ac266b22a30d.png)

외부에 의존하는 도메인 제약 사항은 도메인 서비스인 `Validator`로 분리하였고
도메인 패키지 내에서는 외부에 의존성을 갖지 않도록 인터페이스를 추가하여 개발했습니다.
(ex. `OrderValidator` 구현체에서 `Menus`, `OrderTables` 로 검증을 하고 `Menus`, `OrderTables` 의 구현체는 `infra` 패키지에 위치하므로 도메인 내 클래스들은 외부 도메인에 의존성을 갖지 않음)

그리고 변경 사항을 외부에 전달하기 위해서 도메인 이벤트를 생성하여 전달하는 식으로 구성했습니다.
(ex. `OrderTableGroupingEvent`가 `OrderTableGroup`에서 발생하고 해당 이벤트 핸들러는 주문 테이블 어그리게잇의 application 레벨에서 핸들링 함)

미션이 정말 어려웠던 것 같네요 🥲 하지만 의존성에 대해 고민해볼 수 있는 좋은 기회였던 것 같습니다...

내용이 많지만 리뷰 잘 부탁드리겠습니다...! 😀